### PR TITLE
ddccontrol-db Dell 2007fp

### DIFF
--- a/db/monitor/DELA021.xml
+++ b/db/monitor/DELA021.xml
@@ -3,7 +3,7 @@
 18 1A 1D 1E 20 30 3E 52 AC AE B2 B6 C0 C6 C8 C9 CA D6(01 02 03 04) DF)) -->
 <monitor name="Dell 2007FP (DVI)" init="standard">
 	<!--- Note: "Contrast settings (0x12) doesn't work with DVI, only with VGA" -->
-	<caps add="(vcp(02 04 05 08 0E 10 14(01 06 08 0B) 16 18 1A 1D 1E 20 30 3E 52 AC AE B2 B6 C0 C6 C8 C9 CA D6(01 02 03 04) DF))"/>
+	<caps add="(vcp(02 04 05 08 0E 10 14(01 06 08 0B) 16 18 1A 1D 1E 20 30 60(03 05 07 09) 3E 52 AC AE B2 B6 C0 C6 C8 C9 CA D6(01 02 03 04) DF))"/>
         <controls>
 		<!--- Control 0x02: +/256/65535   [???] -->
 
@@ -13,6 +13,48 @@
                         <value id="cool"   value="8"/>
                         <value id="custom" value="11"/>
                 </control>
+
+    <!-- inputsource has changed in the Dell 2007FP model, using the newer
+    saner settings.
+
+    from EDID Manufactured: Week 21, 2006 and Week 33, 2006
+    when on VGA reads       Control 0x60: +/256/65535 in hex 0x100
+    when on DVI reads       Control 0x60: +/768/65535 in hex 0x300
+    when on Composite reads Control 0x60: +/0/65535 C
+    when on S-Video reads   Control 0x60: +/0/65535 C
+    writing,
+    write 1 goes to VGA
+    write 3 goes blank (Composite or S-Video not sure)
+    write 5 goes blank (Composite or S-Video not sure)
+    write 7 goes to DVI
+    Note the LED input indicator doesn't change.
+
+    from EDID Manufactured: Week 3, 2007
+    reading,
+    when on VGA reads       Control 0x60: +/1/7 C
+    when on DVI reads       Control 0x60: +/3/7
+    when on Composite reads Control 0x60: +/5/7 C
+    when on S-Video reads   Control 0x60: +/7/7 C
+    writing,
+    write 1 goes to VGA
+    write 3 goes to DVI
+    write 5 goes to Composite
+    write 7 goes to S-Video
+
+    Note, the monitor can only be controlled from one i2c bus, which will
+    either be VGA or DVI, whichever was the last enabled port.  That means if
+    you set it to DVI from VGA, then the VGA input can't get it back (same with
+    reverse).  The active i2c bus can set it to Composite or S-Video and move
+    it back, as long as the power doesn't go out, then the VGA input has
+    control.
+    -->
+    <!-- matches a "newer" display manufactured in Week 3, 2007 -->
+    <control id="inputsource" type="list" address="0x60">
+      <value id="vga" value="0x01"/>
+      <value id="dvi" value="0x03"/>
+      <value id="composite" value="0x05"/>
+      <value id="s-video" value="0x07"/>
+    </control>
 
 		<!--- Control 0x60: +/768/65535   [???] -->
 		<!--- Control 0x68: +/256/65535   [???] -->

--- a/db/options.xml
+++ b/db/options.xml
@@ -14,6 +14,9 @@
 				<value id="entertain" name="Entertain"/>
 				<value id="custom" name="Custom"/>
 				<value id="dynamic" name="Dynamic Contrast" /> 
+				<value id="multimedia" name="Multimedia"/>
+				<value id="movie" name="Movie"/>
+				<value id="standard" name="Standard"/>
 			</control>
 			<control id="superbright" type="list" name="Super Bright Mode" address="0xF9">
 				<value id="one" name="One" value="0"/>
@@ -27,6 +30,12 @@
 				<value id="middle" name="Middle"/>
 				<value id="low" name="Low"/>
 				<value id="auto" name="Auto"/>
+			</control>
+			<control id="fengine" type="list" name="f-Engine">
+				<value id="normal" name="Normal" />
+				<value id="user" name="User" />
+				<value id="text" name="Text" />
+				<value id="movie" name="Movie" />
 			</control>
 		</subgroup>
 <!-- Following sub group valid for LG F-Engine monitors -->
@@ -102,6 +111,7 @@
 				<value id="cool6" name="Cool6"/>
 				<value id="cool7" name="Cool7"/>
 				<value id="srgb" name="sRGB"/>
+				<value id="argb" name="Adobe RGB"/>
 				<value id="4000k" name="4000K"/>
 				<value id="5000k" name="5000K"/>
 				<value id="6500k" name="6500K"/>
@@ -270,6 +280,17 @@
 			<control id="inputsource" type="list" name="Input Source Select" address="0x60">
 				<value id="analog" name="Analog"/>
 				<value id="digital" name="Digital"/>
+				<value id="dp" name="DisplayPort"/>
+				<value id="dvi" name="DVI"/>
+				<value id="dvi1" name="DVI-1"/>
+				<value id="dvi2" name="DVI-2"/>
+				<value id="hdmi" name="HDMI"/>
+				<value id="hdmi1" name="HDMI-1"/>
+				<value id="hdmi2" name="HDMI-2"/>
+				<value id="vga" name="VGA"/>
+				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
 			</control>
 			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
 				<value id="auto" name="Automatic" value="0"/>
@@ -280,6 +301,7 @@
 			<control id="dpms" type="list" name="DPMS Control" address="0xd6">
 				<value id="on" name="On"/>
 				<value id="standby" name="Standby"/>
+				<value id="off" name="Off"/>
 			</control>
 			<control id="power" type="list" name="Power control" address="0xe1">
 				<value id="off" name="Off"/>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -288,6 +288,8 @@
 				<value id="hdmi2" name="HDMI-2"/>
 				<value id="vga" name="VGA"/>
 				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
 			</control>
 			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
 				<value id="auto" name="Automatic" value="0"/>


### PR DESCRIPTION
On Tue, Jan 29, 2013 at 4:40 AM, David Fries david@fries.net wrote:

> I have a patch to add inputselect control to DELA021.xml for the Dell
> 2007FP display.

Here are the two commits, thanks for your e-mail response.  It would be nice if the sourceforge repository link could point here.

It's just too bad that this Dell monitor can only be commanded from the DVI or VGA that it is displaying, which means I can't have one system tell it to switch to the other input and be able to get it back.
