### PR TITLE
Added support for AOC2260 (AOC G2260VWQ6)

### DIFF
--- a/db/monitor/AOC2260.xml
+++ b/db/monitor/AOC2260.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<monitor name="AOC 2260" init="standard">
+	<caps add="type(lcd)vcp(vcp(02 04 05 08 0B 0C 10 12 14(01 05 06 08 0B) 16 18 1A 6C 6E 70 AC AE B6 C0 C6 C8 C9 CA CC(01 02 03 04 05 06 07 08 09 0A 0B 0D 12 14 16 1E) D6(01 04) DF 60(01 11) 62 8D(01 02) FF))"/>
+
+    <!-- include AOC family-->
+	<include file="AOClcd"/>
+</monitor>

--- a/db/monitor/AOC2260.xml
+++ b/db/monitor/AOC2260.xml
@@ -9,6 +9,14 @@
 			<value id="hdmi"  value="0x03"/>
 			<value id="dp"    value="0x04"/>
 		</control>
+
+		<!-- read works, write don't -->
+		<control id="language" type="list" address="0xcc">
+			<value id="english" 	value="0x02"/>
+			<value id="french"  	value="0x03"/>
+			<value id="spanish" 	value="0x0a"/>
+			<value id="portuguese"  value="0x08"/>
+		</control>
 	</controls>
 
 	<!-- include AOC family-->

--- a/db/monitor/AOC2260.xml
+++ b/db/monitor/AOC2260.xml
@@ -2,6 +2,15 @@
 <monitor name="AOC 2260" init="standard">
 	<caps add="type(lcd)vcp(vcp(02 04 05 08 0B 0C 10 12 14(01 05 06 08 0B) 16 18 1A 6C 6E 70 AC AE B6 C0 C6 C8 C9 CA CC(01 02 03 04 05 06 07 08 09 0A 0B 0D 12 14 16 1E) D6(01 04) DF 60(01 11) 62 8D(01 02) FF))"/>
 
-    <!-- include AOC family-->
+	<!-- specific controls, but they might(?) be shared with other AOC monitors -->
+	<controls>
+		<control id="inputsource" type="list" address="0x60">
+			<value id="vga"   value="0x01"/>
+			<value id="hdmi"  value="0x03"/>
+			<value id="dp"    value="0x04"/>
+		</control>
+	</controls>
+
+	<!-- include AOC family-->
 	<include file="AOClcd"/>
 </monitor>

--- a/db/monitor/AOClcd.xml
+++ b/db/monitor/AOClcd.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0"?>
 <monitor name="AOC standard LCD" init="standard">
+	<controls>
+		<!-- probably same on all AOC monitors, tested on AOC2260, subset of these can be found in AOCA928 -->
+		<control id="colorpreset" type="list" address="0x14">
+			<value id="srgb"   value="0x01"/>
+			<value id="warm"   value="0x05"/>
+			<value id="normal" value="0x06"/>
+			<value id="cool"   value="0x08"/>
+			<value id="user"   value="0x0b"/>
+		</control>
+	</controls>
+
 	<include file="VESA"/>
 </monitor>

--- a/db/monitor/AOClcd.xml
+++ b/db/monitor/AOClcd.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="AOC standard LCD" init="standard">
+	<include file="VESA"/>
+</monitor>

--- a/doc/monitors/AOC2260.md
+++ b/doc/monitors/AOC2260.md
@@ -21,45 +21,46 @@ Type: LCD
 
 GUI test:
 
-* **OK** - works fine from GUI
+* **OK** - works fine from GUI,
+* **OK, FB** - works, but uses some kind of automatic fallback.
 
 Table shows detected controls for AOC G2260VWQ6:
 
-| Control | valid/current/max | GUI  | Description                     |
-| ------- | ----------------- | ---- | ------------------------------- |
-| 0x02    | +/255/255         |      | ???                             |
-| 0x04    | +/0/1             |      | Restore Factory Defaults        |
-| 0x05    | +/0/1             |      | Restore Brightness and Contrast |
-| 0x08    | +/0/1             |      | Restore Factory Default Color   |
-| 0x0b    | +/50/65535        |      | ???                             |
-| 0x0c    | +/70/126          |      | ???                             |
-| 0x10    | +/29/100          | OK   | Brightness                      |
-| 0x12    | +/50/100          | OK   | Contrast                        |
-| 0x14    | +/11/11           |      | ???                             |
-| 0x16    | +/50/100          | OK   | Red maximum level               |
-| 0x18    | +/49/100          | OK   | Green maximum level             |
-| 0x1a    | +/49/100          | OK   | Blue maximum level              |
-| 0x52    | +/0/255 [???      |      |                                 |
-| 0x60    | +/4/3             |      | Input Source Select             |
-| 0x62    | +/48/100          |      | Audio Speaker Volume Adjust     |
-| 0x6c    | +/50/100          |      | Red minimum level               |
-| 0x6e    | +/50/100          |      | Green minimum level             |
-| 0x70    | +/50/100          |      | Blue minimum level              |
-| 0x8d    | +/2/2             |      | ???                             |
-| 0xac    | +/1964/65281      |      | ???                             |
-| 0xae    | +/5970/65535      |      | ???                             |
-| 0xb2    | +/1/8 [???        |      |                                 |
-| 0xb6    | +/3/4             |      | ???                             |
-| 0xc0    | +/600/65535       |      | ???                             |
-| 0xc6    | +/111/65535       |      | ???                             |
-| 0xc8    | +/18/65535        |      | ???                             |
-| 0xc9    | +/6/65535         |      | ???                             |
-| 0xca    | +/2/2             |      | ???                             |
-| 0xcc    | +/2/255           |      | ???                             |
-| 0xd6    | +/1/4             |      | DPMS Control - On               |
-| 0xdc    | +/4/8 [???        |      |                                 |
-| 0xdf    | +/513/65535       |      | ???                             |
-| 0xf8    | +/0/255 [???      |      |                                 |
-| 0xfe    | +/0/255 [???      |      |                                 |
-| 0xff    | +/0/1             |      | ???                             |
+| Control | valid/current/max | CMD test | GUI test | Description                              |
+| ------- | ----------------- | -------- | -------- | ---------------------------------------- |
+| 0x02    | +/255/255         |          |          | ???                                      |
+| 0x04    | +/0/1             |          |          | Restore Factory Defaults                 |
+| 0x05    | +/0/1             |          |          | Restore Brightness and Contrast          |
+| 0x08    | +/0/1             |          |          | Restore Factory Default Color            |
+| 0x0b    | +/50/65535        |          |          | ???                                      |
+| 0x0c    | +/70/126          |          |          | ???                                      |
+| 0x10    | +/29/100          |          | OK       | Brightness                               |
+| 0x12    | +/50/100          |          | OK       | Contrast                                 |
+| 0x14    | +/11/11           |          | OK       | Color preset (01 - sRGB, 05 - warm, 06 - normal, 08 - cool, 0B - user) |
+| 0x16    | +/50/100          |          | OK       | Red maximum level                        |
+| 0x18    | +/49/100          |          | OK       | Green maximum level                      |
+| 0x1a    | +/49/100          |          | OK       | Blue maximum level                       |
+| 0x52    | +/0/255 [???      |          |          |                                          |
+| 0x60    | +/4/3             | OK       | OK, FB   | Input Source Select (01 - D-SUB, 03 - HDMI, 04 - DisplayPort). Falls back to connected input. |
+| 0x62    | +/48/100          |          |          | Audio Speaker Volume Adjust              |
+| 0x6c    | +/50/100          |          |          | Red minimum level                        |
+| 0x6e    | +/50/100          |          |          | Green minimum level                      |
+| 0x70    | +/50/100          |          |          | Blue minimum level                       |
+| 0x8d    | +/2/2             |          |          | ???                                      |
+| 0xac    | +/1964/65281      |          |          | ???                                      |
+| 0xae    | +/5970/65535      |          |          | ???                                      |
+| 0xb2    | +/1/8 [???        |          |          |                                          |
+| 0xb6    | +/3/4             |          |          | ???                                      |
+| 0xc0    | +/600/65535       |          |          | ???                                      |
+| 0xc6    | +/111/65535       |          |          | ???                                      |
+| 0xc8    | +/18/65535        |          |          | ???                                      |
+| 0xc9    | +/6/65535         |          |          | ???                                      |
+| 0xca    | +/2/2             |          |          | ???                                      |
+| 0xcc    | +/2/255           |          |          | ???                                      |
+| 0xd6    | +/1/4             |          |          | DPMS Control - On                        |
+| 0xdc    | +/4/8 [???        |          |          |                                          |
+| 0xdf    | +/513/65535       |          |          | ???                                      |
+| 0xf8    | +/0/255 [???      |          |          |                                          |
+| 0xfe    | +/0/255 [???      |          |          |                                          |
+| 0xff    | +/0/1             |          |          | ???                                      |
 

--- a/doc/monitors/AOC2260.md
+++ b/doc/monitors/AOC2260.md
@@ -1,0 +1,65 @@
+# AOC2260
+
+EDID readings:
+Plug and Play ID: AOC2260 [VESA standard monitor]
+Input type: Digital
+
+Tested on displays:
+
+* G2260VWQ6
+
+## Capabilities
+
+```
+Raw output: (prot(monitor)type(lcd)model(G2260VWQ6)cmds(010203070C4EF3E3)vcp(020405080B0C101214(010506080B)16181A6C6E70ACAEB6C0C6C8C9CACC(0102030405060708090A0B0D1214161E)D6(0104)DF60(0111)628D(0102)FF)mswhql(1)mccs_ver(2.1)asset_eep(32)mpu_ver(01))
+Parsed output:
+VCP: 02 04 05 08 0b 0c 10 12 14 16 18 1a 60 62 6c 6e 70 8d ac ae b6 c0 c6 c8 c9 ca cc d6 df ff
+Type: LCD
+```
+
+## Controls
+
+GUI test:
+
+* **OK** - works fine from GUI
+
+Table shows detected controls for AOC G2260VWQ6:
+
+| Control | valid/current/max | GUI  | Description                     |
+| ------- | ----------------- | ---- | ------------------------------- |
+| 0x02    | +/255/255         |      | ???                             |
+| 0x04    | +/0/1             |      | Restore Factory Defaults        |
+| 0x05    | +/0/1             |      | Restore Brightness and Contrast |
+| 0x08    | +/0/1             |      | Restore Factory Default Color   |
+| 0x0b    | +/50/65535        |      | ???                             |
+| 0x0c    | +/70/126          |      | ???                             |
+| 0x10    | +/29/100          | OK   | Brightness                      |
+| 0x12    | +/50/100          | OK   | Contrast                        |
+| 0x14    | +/11/11           |      | ???                             |
+| 0x16    | +/50/100          | OK   | Red maximum level               |
+| 0x18    | +/49/100          | OK   | Green maximum level             |
+| 0x1a    | +/49/100          | OK   | Blue maximum level              |
+| 0x52    | +/0/255 [???      |      |                                 |
+| 0x60    | +/4/3             |      | Input Source Select             |
+| 0x62    | +/48/100          |      | Audio Speaker Volume Adjust     |
+| 0x6c    | +/50/100          |      | Red minimum level               |
+| 0x6e    | +/50/100          |      | Green minimum level             |
+| 0x70    | +/50/100          |      | Blue minimum level              |
+| 0x8d    | +/2/2             |      | ???                             |
+| 0xac    | +/1964/65281      |      | ???                             |
+| 0xae    | +/5970/65535      |      | ???                             |
+| 0xb2    | +/1/8 [???        |      |                                 |
+| 0xb6    | +/3/4             |      | ???                             |
+| 0xc0    | +/600/65535       |      | ???                             |
+| 0xc6    | +/111/65535       |      | ???                             |
+| 0xc8    | +/18/65535        |      | ???                             |
+| 0xc9    | +/6/65535         |      | ???                             |
+| 0xca    | +/2/2             |      | ???                             |
+| 0xcc    | +/2/255           |      | ???                             |
+| 0xd6    | +/1/4             |      | DPMS Control - On               |
+| 0xdc    | +/4/8 [???        |      |                                 |
+| 0xdf    | +/513/65535       |      | ???                             |
+| 0xf8    | +/0/255 [???      |      |                                 |
+| 0xfe    | +/0/255 [???      |      |                                 |
+| 0xff    | +/0/1             |      | ???                             |
+

--- a/doc/monitors/AOC2260.md
+++ b/doc/monitors/AOC2260.md
@@ -30,9 +30,9 @@ Table shows detected controls for AOC G2260VWQ6:
 | Control | valid/current/max | CMD test | GUI test | Description                              |
 | ------- | ----------------- | -------- | -------- | ---------------------------------------- |
 | 0x02    | +/255/255         |          |          | ???                                      |
-| 0x04    | +/0/1             |          |          | Restore Factory Defaults                 |
-| 0x05    | +/0/1             |          |          | Restore Brightness and Contrast          |
-| 0x08    | +/0/1             |          |          | Restore Factory Default Color            |
+| 0x04    | +/0/1             |          | OK       | Restore Factory Defaults                 |
+| 0x05    | +/0/1             |          | OK       | Restore Brightness and Contrast          |
+| 0x08    | +/0/1             |          | OK       | Restore Factory Default Color            |
 | 0x0b    | +/50/65535        |          |          | ???                                      |
 | 0x0c    | +/70/126          |          |          | ???                                      |
 | 0x10    | +/29/100          |          | OK       | Brightness                               |
@@ -44,9 +44,9 @@ Table shows detected controls for AOC G2260VWQ6:
 | 0x52    | +/0/255 [???      |          |          |                                          |
 | 0x60    | +/4/3             | OK       | OK, FB   | Input Source Select (01 - D-SUB, 03 - HDMI, 04 - DisplayPort). Falls back to connected input. |
 | 0x62    | +/48/100          | OK       | OK       | Audio Speaker Volume Adjust              |
-| 0x6c    | +/50/100          |          |          | Red minimum level                        |
-| 0x6e    | +/50/100          |          |          | Green minimum level                      |
-| 0x70    | +/50/100          |          |          | Blue minimum level                       |
+| 0x6c    | +/50/100          |          | OK       | Red minimum level                        |
+| 0x6e    | +/50/100          |          | OK       | Green minimum level                      |
+| 0x70    | +/50/100          |          | OK       | Blue minimum level                       |
 | 0x8d    | +/2/2             |          |          | ???                                      |
 | 0xac    | +/1964/65281      |          |          | ???                                      |
 | 0xae    | +/5970/65535      |          |          | ???                                      |
@@ -58,7 +58,7 @@ Table shows detected controls for AOC G2260VWQ6:
 | 0xc9    | +/6/65535         |          |          | ???                                      |
 | 0xca    | +/2/2             |          |          | ???                                      |
 | 0xcc    | +/2/255           | OK - RO  | OK - RO  | Language select                          |
-| 0xd6    | +/1/4             |          |          | DPMS Control - On                        |
+| 0xd6    | +/1/4             |          | OK       | DPMS Control - On                        |
 | 0xdc    | +/4/8 [???        |          |          |                                          |
 | 0xdf    | +/513/65535       |          |          | ???                                      |
 | 0xf8    | +/0/255 [???      |          |          |                                          |

--- a/doc/monitors/AOC2260.md
+++ b/doc/monitors/AOC2260.md
@@ -23,6 +23,7 @@ GUI test:
 
 * **OK** - works fine from GUI,
 * **OK, FB** - works, but uses some kind of automatic fallback.
+* **OK, RO** - works, but in **r**ead**o**nly mode (doesn't set the value)
 
 Table shows detected controls for AOC G2260VWQ6:
 
@@ -42,7 +43,7 @@ Table shows detected controls for AOC G2260VWQ6:
 | 0x1a    | +/49/100          |          | OK       | Blue maximum level                       |
 | 0x52    | +/0/255 [???      |          |          |                                          |
 | 0x60    | +/4/3             | OK       | OK, FB   | Input Source Select (01 - D-SUB, 03 - HDMI, 04 - DisplayPort). Falls back to connected input. |
-| 0x62    | +/48/100          |          |          | Audio Speaker Volume Adjust              |
+| 0x62    | +/48/100          | OK       | OK       | Audio Speaker Volume Adjust              |
 | 0x6c    | +/50/100          |          |          | Red minimum level                        |
 | 0x6e    | +/50/100          |          |          | Green minimum level                      |
 | 0x70    | +/50/100          |          |          | Blue minimum level                       |
@@ -56,7 +57,7 @@ Table shows detected controls for AOC G2260VWQ6:
 | 0xc8    | +/18/65535        |          |          | ???                                      |
 | 0xc9    | +/6/65535         |          |          | ???                                      |
 | 0xca    | +/2/2             |          |          | ???                                      |
-| 0xcc    | +/2/255           |          |          | ???                                      |
+| 0xcc    | +/2/255           | OK - RO  | OK - RO  | Language select                          |
 | 0xd6    | +/1/4             |          |          | DPMS Control - On                        |
 | 0xdc    | +/4/8 [???        |          |          |                                          |
 | 0xdf    | +/513/65535       |          |          | ???                                      |


### PR DESCRIPTION
I've made following changes to support basic controls of AOC G2260VWQ6:

* created `AOC2260` profile and `AOClcd` (AOC standard LCD) profile,
* tested basic controls and documented testing in `doc/monitors/AOC2260.md`,
* figured out some controls and improved `AOC2260` and `AOClcd` profiles.