### PR TITLE
Added support for DELL U3818DW and PBP/PIP controls

### DIFF
--- a/db/monitor/DELA0EF.xml
+++ b/db/monitor/DELA0EF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 2.0 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI2 2.0)" init="standard">
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI1 1.4 (reports a different EDID) -->
+<monitor name="DELL U3818DW (HDMI1 1.4)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F0.xml
+++ b/db/monitor/DELA0F0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 2.0 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI2 2.0)" init="standard">
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI1 2.0 (reports a different EDID) -->
+<monitor name="DELL U3818DW (HDMI1 2.0)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F1.xml
+++ b/db/monitor/DELA0F1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI 1.4 (reports a different EDID)-->
+<monitor name="DELL U3818DW (HDMI 1.4)" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
+
+	<!-- use the settings from the DisplayPort version of the monitor -->
+	<include file="DELA0F3"/>
+
+</monitor>

--- a/db/monitor/DELA0F1.xml
+++ b/db/monitor/DELA0F1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI 1.4 (reports a different EDID)-->
-<monitor name="DELL U3818DW (HDMI 1.4)" init="standard">
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 1.4 (reports a different EDID) -->
+<monitor name="DELL U3818DW (HDMI2 1.4)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F2.xml
+++ b/db/monitor/DELA0F2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI 2.0 (reports a different EDID)-->
+<monitor name="DELL U3818DW (HDMI 2.0)" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
+
+	<!-- use the settings from the DisplayPort version of the monitor -->
+	<include file="DELA0F3"/>
+
+</monitor>

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!-- DELL UltraSharp 38 Monitor (Model 2017) -->
+<monitor name="DELL U8318DW" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
+
+	<!-- Vendor-specific controls for the DELL monitor -->
+	<controls>
+		<control id="PbP"               type="list" address="0xe9">
+			<value id="Off"         value="0x00"/>
+			<value id="PbP"         value="0x24"/>
+			<value id="PiP large"   value="0x22"/>
+			<value id="PiP small"   value="0x21"/>
+		</control>
+		<control id="maininputsource" type="list" address="0x60">
+			<value id="hdmi1"     value="0x11"/>
+			<value id="hdmi2"     value="0x12"/>
+			<value id="dp"        value="0x0f"/>
+			<value id="usb-c"     value="0x1b"/>
+		</control>
+		<control id="subinputsource1" type="list" address="0xe8">
+			<value id="hdmi1"     value="0x11"/>
+			<value id="hdmi2"     value="0x12"/>
+			<value id="dp"        value="0x0f"/>
+			<value id="usb-c"     value="0x1b"/>
+		</control>
+	</controls>
+
+        <!-- enable the standard VESA controls too -->
+	<include file="VESA"/>
+
+</monitor>

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0"?>
 <!-- DELL UltraSharp 38 Monitor (Model 2017) -->
-<monitor name="DELL U8318DW" init="standard">
+<monitor name="DELL U3818DW" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- Vendor-specific controls for the DELL monitor -->
 	<controls>
-		<control id="PbP"               type="list" address="0xe9">
-			<value id="Off"         value="0x00"/>
-			<value id="PbP"         value="0x24"/>
-			<value id="PiP large"   value="0x22"/>
-			<value id="PiP small"   value="0x21"/>
+		<control id="PbP" type="list" address="0xe9">
+			<value id="Off"		value="0x00"/>
+			<value id="PbP"		value="0x24"/>
+			<value id="PiP large"	value="0x22"/>
+			<value id="PiP small"	value="0x21"/>
 		</control>
 		<control id="maininputsource" type="list" address="0x60">
-			<value id="hdmi1"     value="0x11"/>
-			<value id="hdmi2"     value="0x12"/>
-			<value id="dp"        value="0x0f"/>
-			<value id="usb-c"     value="0x1b"/>
+			<value id="hdmi1"	value="0x11"/>
+			<value id="hdmi2"	value="0x12"/>
+			<value id="dp"		value="0x0f"/>
+			<value id="usb-c"	value="0x1b"/>
 		</control>
 		<control id="subinputsource1" type="list" address="0xe8">
-			<value id="hdmi1"     value="0x11"/>
-			<value id="hdmi2"     value="0x12"/>
-			<value id="dp"        value="0x0f"/>
-			<value id="usb-c"     value="0x1b"/>
+			<value id="hdmi1"	value="0x11"/>
+			<value id="hdmi2"	value="0x12"/>
+			<value id="dp"		value="0x0f"/>
+			<value id="usb-c"	value="0x1b"/>
 		</control>
 	</controls>
 
-        <!-- enable the standard VESA controls too -->
+	<!-- enable the standard VESA controls too -->
 	<include file="VESA"/>
 
 </monitor>

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- DELL UltraSharp 38 Monitor (Model 2017) via DisplayPort -->
-<monitor name="DELL U3818DW (DP)" init="standard">
+<monitor name="DELL U3818DW (DisplayPort)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- Vendor-specific controls for the DELL monitor -->

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) -->
-<monitor name="DELL U3818DW" init="standard">
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via DisplayPort -->
+<monitor name="DELL U3818DW (DP)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- Vendor-specific controls for the DELL monitor -->

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -11,13 +11,13 @@
 			<value id="PiP large"	value="0x22"/>
 			<value id="PiP small"	value="0x21"/>
 		</control>
-		<control id="maininputsource" type="list" address="0x60">
+		<control id="inputsource" type="list" address="0x60">
 			<value id="hdmi1"	value="0x11"/>
 			<value id="hdmi2"	value="0x12"/>
 			<value id="dp"		value="0x0f"/>
 			<value id="usb-c"	value="0x1b"/>
 		</control>
-		<control id="subinputsource1" type="list" address="0xe8">
+		<control id="inputsource_sub1" type="list" address="0xe8">
 			<value id="hdmi1"	value="0x11"/>
 			<value id="hdmi2"	value="0x12"/>
 			<value id="dp"		value="0x0f"/>

--- a/db/monitor/DELA0F4.xml
+++ b/db/monitor/DELA0F4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 2.0 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI2 2.0)" init="standard">
+<!-- DELL UltraSharp 38 Monitor (Model 2017) via USB Type-C (reports a different EDID) -->
+<monitor name="DELL U3818DW (USB Type-C)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -375,7 +375,7 @@
 				<value id="component" name="Component"/>
 				<value id="s-video" name="S-Video"/>
 				<value id="composite" name="Composite"/>
-                                <value id="usb-c" name = "USB-C" />
+				<value id="usb-c" name = "USB-C" />
 			</control>
 			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
 				<value id="auto" name="Automatic" value="0"/>
@@ -415,7 +415,7 @@
 			</control>
 		</subgroup>
 	</group>
-        <!-- Picture-by-Picture ("split screen") and Picture-in-Picture settings -->
+<!-- Picture-by-Picture ("split screen") and Picture-in-Picture settings -->
 	<group name="PIP/PBP">
 		<subgroup name="PIP/PBP settings">
 			<control id="PbP" type="list" name="PbP/PIP mode"  address="0xe9">
@@ -440,10 +440,10 @@
 				<value id="component" name="Component"/>
 				<value id="s-video" name="S-Video"/>
 				<value id="composite" name="Composite"/>
-                                <value id="usb-c" name = "USB-C" />
+				<value id="usb-c" name = "USB-C" />
 			</control>
-                        <!-- some displays do now support even four split screens (e. g. LG 43UD79-B)
-                             so more sub inputs could be added here later to support those displays by incrementing the sub input number -->
+			<!-- some displays do now support even four split screens (e. g. LG 43UD79-B)
+			     so more sub inputs could be added here later to support those displays by incrementing the sub input number -->
 			<control id="subinputsource1" type="list" name="Input Source Select (Sub #1)">
 				<value id="analog" name="Analog"/>
 				<value id="digital" name="Digital"/>
@@ -460,7 +460,7 @@
 				<value id="component" name="Component"/>
 				<value id="s-video" name="S-Video"/>
 				<value id="composite" name="Composite"/>
-                                <value id="usb-c" name = "USB-C" />
+				<value id="usb-c" name = "USB-C" />
 			</control>
 		</subgroup>
 	</group>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -291,6 +291,68 @@
 			<control id="sharpness" type="value" name="Sharpness" address="0x8c"/>
 		</subgroup>
 	</group>
+	<group name="Input settings">
+		<!-- Picture-by-Picture ("split screen") and Picture-in-Picture settings are vendor-specific -->
+		<subgroup name="PIP/PBP">
+			<control id="PbP" type="list" name="PbP/PIP mode">
+				<value id="Off" name="Off"/>
+				<value id="PbP" name="PbP"/>
+				<value id="PiP large" name="PiP Large"/>
+				<value id="PiP small" name="PiP Small"/>
+			</control>
+		</subgroup>
+		<subgroup name="Input sources">
+			<control id="inputlevel" type="list" name="Input level Select" address="0x5E">
+				<!-- To be completed -->
+			</control>
+			<control id="resolutionnotifier" type="list" name="Display Resolution Notifier" address="0xf6">
+				<value id="on" name="On"/>
+				<value id="off" name="Off"/>
+			</control>
+			<control id="inputsource" type="list" name="Input Source Select (Main)" address="0x60">
+				<value id="analog" name="Analog"/>
+				<value id="digital" name="Digital"/>
+				<value id="dp" name="DisplayPort"/>
+				<value id="dvi" name="DVI"/>
+				<value id="dvi1" name="DVI-1"/>
+				<value id="dvi2" name="DVI-2"/>
+				<value id="hdmi" name="HDMI"/>
+				<value id="hdmi1" name="HDMI-1"/>
+				<value id="hdmi2" name="HDMI-2"/>
+				<value id="hdmi-mhl" name="HDMI (MHL)"/>
+				<value id="mdp" name="mDP"/>
+				<value id="vga" name="VGA"/>
+				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
+				<value id="usb-c" name="USB-C"/>
+			</control>
+			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
+				<value id="auto" name="Automatic" value="0"/>
+				<value id="manual" name="Manual" value="1"/>
+			</control>
+			<!-- some displays do now support even four PBP split screens (e. g. LG 43UD79-B)
+			     so more sub inputs could be added here later to support those displays by incrementing the sub input number -->
+			<control id="inputsource_sub1" type="list" name="Input Source Select (Sub #1)">
+				<value id="analog" name="Analog"/>
+				<value id="digital" name="Digital"/>
+				<value id="dp" name="DisplayPort"/>
+				<value id="dvi" name="DVI"/>
+				<value id="dvi1" name="DVI-1"/>
+				<value id="dvi2" name="DVI-2"/>
+				<value id="hdmi" name="HDMI"/>
+				<value id="hdmi1" name="HDMI-1"/>
+				<value id="hdmi2" name="HDMI-2"/>
+				<value id="hdmi-mhl" name="HDMI (MHL)"/>
+				<value id="mdp" name="mDP"/>
+				<value id="vga" name="VGA"/>
+				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
+				<value id="usb-c" name="USB-C"/>
+			</control>
+		</subgroup>
+	</group>
 	<group name="Others">
 		<subgroup name="Restore defaults">
 			<control id="defaults" type="command" name="Restore Factory Defaults" address="0x04" refresh="all"/>
@@ -351,37 +413,6 @@
 				<value id="serbocroatian" name="SiGC/BiH/CRO (Serbo-Croatian)"/>
 			</control>
 		</subgroup>
-		<subgroup name="Input settings">
-			<control id="inputlevel" type="list" name="Input level Select" address="0x5E">
-				<!-- To be completed -->
-			</control>
-			<control id="resolutionnotifier" type="list" name="Display Resolution Notifier" address="0xf6">
-				<value id="on" name="On"/>
-				<value id="off" name="Off"/>
-			</control>
-			<control id="inputsource" type="list" name="Input Source Select" address="0x60">
-				<value id="analog" name="Analog"/>
-				<value id="digital" name="Digital"/>
-				<value id="dp" name="DisplayPort"/>
-				<value id="dvi" name="DVI"/>
-				<value id="dvi1" name="DVI-1"/>
-				<value id="dvi2" name="DVI-2"/>
-				<value id="hdmi" name="HDMI"/>
-				<value id="hdmi1" name="HDMI-1"/>
-				<value id="hdmi2" name="HDMI-2"/>
-				<value id="hdmi-mhl" name="HDMI (MHL)"/>
-				<value id="mdp" name="mDP"/>
-				<value id="vga" name="VGA"/>
-				<value id="component" name="Component"/>
-				<value id="s-video" name="S-Video"/>
-				<value id="composite" name="Composite"/>
-				<value id="usb-c" name = "USB-C" />
-			</control>
-			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
-				<value id="auto" name="Automatic" value="0"/>
-				<value id="manual" name="Manual" value="1"/>
-			</control>
-		</subgroup>
 		<subgroup name="Power control">
 			<control id="dpms" type="list" name="DPMS Control" address="0xd6">
 				<value id="on" name="On"/>
@@ -415,54 +446,4 @@
 			</control>
 		</subgroup>
 	</group>
-<!-- Picture-by-Picture ("split screen") and Picture-in-Picture settings -->
-	<group name="PIP/PBP">
-		<subgroup name="PIP/PBP settings">
-			<control id="PbP" type="list" name="PbP/PIP mode"  address="0xe9">
-				<value id="Off" name="Off"/>
-				<value id="PbP"  name="PbP"/>
-				<value id="PiP large"  name="PiP Large"/>
-				<value id="PiP small"  name="PiP Small"/>
-			</control>
-			<control id="maininputsource" type="list" name="Input Source Select (Main)">
-				<value id="analog" name="Analog"/>
-				<value id="digital" name="Digital"/>
-				<value id="dp" name="DisplayPort"/>
-				<value id="dvi" name="DVI"/>
-				<value id="dvi1" name="DVI-1"/>
-				<value id="dvi2" name="DVI-2"/>
-				<value id="hdmi" name="HDMI"/>
-				<value id="hdmi1" name="HDMI-1"/>
-				<value id="hdmi2" name="HDMI-2"/>
-				<value id="hdmi-mhl" name="HDMI (MHL)"/>
-				<value id="mdp" name="mDP"/>
-				<value id="vga" name="VGA"/>
-				<value id="component" name="Component"/>
-				<value id="s-video" name="S-Video"/>
-				<value id="composite" name="Composite"/>
-				<value id="usb-c" name = "USB-C" />
-			</control>
-			<!-- some displays do now support even four split screens (e. g. LG 43UD79-B)
-			     so more sub inputs could be added here later to support those displays by incrementing the sub input number -->
-			<control id="subinputsource1" type="list" name="Input Source Select (Sub #1)">
-				<value id="analog" name="Analog"/>
-				<value id="digital" name="Digital"/>
-				<value id="dp" name="DisplayPort"/>
-				<value id="dvi" name="DVI"/>
-				<value id="dvi1" name="DVI-1"/>
-				<value id="dvi2" name="DVI-2"/>
-				<value id="hdmi" name="HDMI"/>
-				<value id="hdmi1" name="HDMI-1"/>
-				<value id="hdmi2" name="HDMI-2"/>
-				<value id="hdmi-mhl" name="HDMI (MHL)"/>
-				<value id="mdp" name="mDP"/>
-				<value id="vga" name="VGA"/>
-				<value id="component" name="Component"/>
-				<value id="s-video" name="S-Video"/>
-				<value id="composite" name="Composite"/>
-				<value id="usb-c" name = "USB-C" />
-			</control>
-		</subgroup>
-	</group>
-
 </options>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -375,6 +375,7 @@
 				<value id="component" name="Component"/>
 				<value id="s-video" name="S-Video"/>
 				<value id="composite" name="Composite"/>
+                                <value id="usb-c" name = "USB-C" />
 			</control>
 			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
 				<value id="auto" name="Automatic" value="0"/>
@@ -414,4 +415,54 @@
 			</control>
 		</subgroup>
 	</group>
+        <!-- Picture-by-Picture ("split screen") and Picture-in-Picture settings -->
+	<group name="PIP/PBP">
+		<subgroup name="PIP/PBP settings">
+			<control id="PbP" type="list" name="PbP/PIP mode"  address="0xe9">
+				<value id="Off" name="Off"/>
+				<value id="PbP"  name="PbP"/>
+				<value id="PiP large"  name="PiP Large"/>
+				<value id="PiP small"  name="PiP Small"/>
+			</control>
+			<control id="maininputsource" type="list" name="Input Source Select (Main)">
+				<value id="analog" name="Analog"/>
+				<value id="digital" name="Digital"/>
+				<value id="dp" name="DisplayPort"/>
+				<value id="dvi" name="DVI"/>
+				<value id="dvi1" name="DVI-1"/>
+				<value id="dvi2" name="DVI-2"/>
+				<value id="hdmi" name="HDMI"/>
+				<value id="hdmi1" name="HDMI-1"/>
+				<value id="hdmi2" name="HDMI-2"/>
+				<value id="hdmi-mhl" name="HDMI (MHL)"/>
+				<value id="mdp" name="mDP"/>
+				<value id="vga" name="VGA"/>
+				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
+                                <value id="usb-c" name = "USB-C" />
+			</control>
+                        <!-- some displays do now support even four split screens (e. g. LG 43UD79-B)
+                             so more sub inputs could be added here later to support those displays by incrementing the sub input number -->
+			<control id="subinputsource1" type="list" name="Input Source Select (Sub #1)">
+				<value id="analog" name="Analog"/>
+				<value id="digital" name="Digital"/>
+				<value id="dp" name="DisplayPort"/>
+				<value id="dvi" name="DVI"/>
+				<value id="dvi1" name="DVI-1"/>
+				<value id="dvi2" name="DVI-2"/>
+				<value id="hdmi" name="HDMI"/>
+				<value id="hdmi1" name="HDMI-1"/>
+				<value id="hdmi2" name="HDMI-2"/>
+				<value id="hdmi-mhl" name="HDMI (MHL)"/>
+				<value id="mdp" name="mDP"/>
+				<value id="vga" name="VGA"/>
+				<value id="component" name="Component"/>
+				<value id="s-video" name="S-Video"/>
+				<value id="composite" name="Composite"/>
+                                <value id="usb-c" name = "USB-C" />
+			</control>
+		</subgroup>
+	</group>
+
 </options>


### PR DESCRIPTION
I have created a DB file for the monitor + extended the options.xml to support picture-by-picture  (PBP/PIP) settings which split the screen into two parts an allow the visualisation of different input signals in each part (e. g. two computers).

See issue #70 

For a better usability I have combined added the input source selection for every "split screen" into the same sub group.

The settings look like this:
![screenshot for del u3818dw](https://user-images.githubusercontent.com/11374410/44946282-c0541d00-adf9-11e8-8d03-a724e53a9325.png)

Other monitors supporting PBP/PIB could reuse my control defintions in the `options.xml`file...