### PR TITLE
Add alias DELF015 for DELL U2410F

### DIFF
--- a/db/monitor/DELF015.xml
+++ b/db/monitor/DELF015.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2410f" init="standard">
+	<!-- Dell U2410F (DELF015) connected with DVI-D 1 and DVI-D 2, should be same as DELF016 -->
+	<include file="DELF016.xml"/>
+</monitor>

--- a/db/monitor/DELF015.xml
+++ b/db/monitor/DELF015.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <monitor name="Dell U2410f" init="standard">
 	<!-- Dell U2410F (DELF015) connected with DVI-D 1 and DVI-D 2, should be same as DELF016 -->
-	<include file="DELF016.xml"/>
+	<include file="DELF016"/>
 </monitor>


### PR DESCRIPTION
From https://github.com/ddccontrol/ddccontrol-db/pull/75#issuecomment-524557632:

> Results for Dell U2410F (DELF015) connected with DVI-D 1 and DVI-D 2:

It seems to be the same monitor.