### PR TITLE
account for "6F" variant of Dell U2515H

### DIFF
--- a/db/monitor/DELD06F.xml
+++ b/db/monitor/DELD06F.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2515H" init="standard">
+    <!--- CAPS: (prot(monitor)type(LCD)model(U2515H)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1)) -->
+	<caps add="(cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05))"/>
+	<controls>
+        <control id="inputsource" type="list" address="0x60">
+            <value id="dp" value="0x0f"/>
+            <value id="mdp" value="0x10"/>
+            <value id="hdmi1" value="0x11"/>
+            <value id="hdmi2" value="0x12"/>
+        </control>
+	</controls>
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELD06F.xml
+++ b/db/monitor/DELD06F.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
 <monitor name="Dell U2515H" init="standard">
-    <!--- CAPS: (prot(monitor)type(LCD)model(U2515H)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1)) -->
-	<caps add="(cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05))"/>
-	<controls>
-        <control id="inputsource" type="list" address="0x60">
-            <value id="dp" value="0x0f"/>
-            <value id="mdp" value="0x10"/>
-            <value id="hdmi1" value="0x11"/>
-            <value id="hdmi2" value="0x12"/>
-        </control>
-	</controls>
-	<include file="VESA"/>
+	<include file="DELD070.xml"/>
 </monitor>

--- a/db/monitor/DELD06F.xml
+++ b/db/monitor/DELD06F.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <monitor name="Dell U2515H" init="standard">
-	<include file="DELD070.xml"/>
+	<include file="DELD070"/>
 </monitor>


### PR DESCRIPTION
my Dell U2515H is identified with another internal code, which is the same, but ending in `6F`. This prevents `ddccontrol` from working, but copying the `70` variant to `6F` variant corrects the issue and `ddccontrol` works again.