### PR TITLE
Add support for AOC I2269Vwm (AOC2269)

### DIFF
--- a/db/monitor/AOC2269.xml
+++ b/db/monitor/AOC2269.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<monitor name="AOC 2269" init="standard">
+    <caps add="type(lcd)vcp(vcp(02 04 05 08 0B 0C 10 12 14(01 05 06 08 0B) 16 18 1A 6C 6E 70 AC AE B6 C0 C6 C8 C9 CA CC(01 02 03 04 05 06 07 08 09 0A 0B 0D 12 14 16 1E) D6(01 04) DF 60(01 11 12) 62 8D(0102) FF))"/>
+
+	<!-- specific controls, but they might(?) be shared with other AOC monitors -->
+	<controls>
+		<control id="inputsource" type="list" address="0x60">
+			<value id="vga"   value="0x01"/>
+			<value id="hdmi1" value="0x03"/>
+			<value id="hdmi2" value="0x04"/>
+		</control>
+
+		<control id="language" type="list" address="0xcc">
+			<value id="chinese_tw" 	value="0x01"/>
+			<value id="english" 	value="0x02"/>
+			<value id="french"  	value="0x03"/>
+			<value id="german"  	value="0x04"/>
+			<value id="italian"  	value="0x05"/>
+			<value id="japanese" 	value="0x06"/>
+			<value id="korean"      value="0x07"/>
+			<value id="portuguese"  value="0x08"/>
+			<value id="russian"     value="0x09"/>
+			<value id="spanish" 	value="0x0a"/>
+			<value id="swedish"     value="0x0b"/>
+			<value id="chinese"     value="0x0d"/>
+			<value id="czech"       value="0x12"/>
+			<value id="dutch"       value="0x14"/>
+			<value id="finnish"     value="0x16"/>
+			<value id="polish"      value="0x1e"/>
+		</control>
+	</controls>
+
+	<!-- include AOC family-->
+	<include file="AOClcd"/>
+</monitor>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -439,8 +439,10 @@
 			<control id="language" type="list" name="Language select" address="0x68">
 				<value id="english"       name="English"/>
 				<value id="french"        name="Français (French)"/>
+				<value id="finnish"       name="Suomi (Finnish)"/>
 				<value id="german"        name="Deutsch (German)"/>
 				<value id="italian"       name="Italiano (Italian)"/>
+                <value id="korean"        name="한국어 (Korean)"/>
 				<value id="spanish"       name="Castellano (Spanish)"/>
 				<value id="russian"       name="Русский (Russian)"/>
 				<value id="swedish"       name="Svenska (Swedish)"/>


### PR DESCRIPTION
A quirk here is that HDMI-2 and DP inputs both show up as value `4` of the control `inputsource`, but none of them gets selected when you write this control (the screen gets blank, then goes back to the same input it was on). VGA and HDMI-1, though, are switched without a problem.

Also, I had to add Korean and Finnish language ids because the monitor has these languages while `options.xml.in` didn't.