### PR TITLE
Dell U3415W support

### DIFF
--- a/db/monitor/DELA0A6.xml
+++ b/db/monitor/DELA0A6.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<monitor name="DELL D3415W (DP)" init="standard">
+  <!-- original caps -->
+  <caps add="(prot(monitor)type(LCD)model(U3415)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) E4(00 01) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
+
+<!--
+  Identifies as DELA0A6 on DP input.
+  Identifies as DELA0A7 on mDP input.
+  Identifies as DELA0A8 on MHL input.
+  Identifies as DELA0AA on HDMI input.
+
+  (prot(monitor)type(LCD)model(U3415)
+  cmds(01 02 03 07 0C E3 F3)
+  vcp(02 04 05    08    10 12 14(04 0B 05 06 08 09 0C) 16 18 1A    52 60(0F 10 11 12)
+    AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF
+    E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) E4(00 01) F0(00 08) F1(01 02) F2 FD)
+  mswhql(1)asset_eep(40)mccs_ver(2.1))
+-->
+  <controls>
+
+    <control id="colorpreset" type="list" address="0x14">
+      <value id="5000k" value="4"/>
+      <value id="6500k" value="5"/>
+      <value id="7500k" value="6"/>
+      <value id="9300k" value="8"/>
+      <value id="10000k" value="9"/>
+      <value id="5700k" value="12"/>
+    </control>
+
+    <control id="inputsource" type="list" address="0x60">
+      <value id="dp" value="0x0f"/>
+      <value id="mdp" value="0x10"/>
+      <value id="hdmi" value="0x11"/>
+      <value id="hdmi-mhl" value="0x12"/>
+    </control>
+
+    <control id="audiospeakervolume" address="0x62"/>
+
+    <!-- Read-only, changes when color is set via OSD.
+    <control id="colorpreset" type="list" address="0xe2">
+      <value id="standard" value="0"/>
+      <value id="multimedia" value="1"/>
+      <value id="movie" value="3"/>
+      <value id="game" value="4"/>
+      <value id="colortemp_5000k" value="12"/>
+      <value id="colortemp_5700k" value="13"/>
+      <value id="colortemp_6500k" value="15"/>
+      <value id="colortemp_7500k" value="16"/>
+      <value id="colortemp_9300k" value="17"/>
+      <value id="colortemp_10000k" value="19"/>
+      <value id="customcolor" value="20"/>
+      <value id="paper" value="25"/>
+    </control>
+    -->
+
+    <control id="coloruniformity" type="list" address="0xe4">
+      <value id="off" value="1"/>
+      <value id="calibrated" value="1"/>
+    </control>
+
+    <!-- Writing 8 turns on paper mode. Can't write any other values. -->
+    <control id="dellpaper" address="0xf0">
+      <value id="set" value="0x08"/>
+    </control>
+
+    <!-- Read-only, combination of resolution and refresh rate.
+    <control id="hsyncfrequency" address="0xac">
+      <value id="3440x1440@30" value="43900"/>
+      <value id="3440x1440@50" value="8164"/>
+      <value id="2560x1440@60" value="23564"/>
+      <value id="2560x1080@60" value="564"/>
+      <value id="2560x1080@59.94" value="464"/>
+      <value id="1920x1080@60" value="2064"/>
+      <value id="1920x1080@59.94" value="1964"/>
+      <value id="1920x1080@50" value="56300"/>
+    </control>
+    -->
+
+    <!-- Have not tried to change, Vertical Sync Frequency (x100 Hz)? -->
+    <!-- <control id="vsyncfrequency" address="0xae"> -->
+
+    <!-- Have not tried to change, Power-on Hours -->
+    <!-- <control id="poweronhours" address="0xc0"/> -->
+
+    <!-- Read-only, not in the caps, OSD is active -->
+    <!-- <control id="osd" type="list" address="0xca"/> -->
+
+    <!-- Read-only, OSD language.
+    <control id="language" type="list" address="0xcc">
+      <value id="english"  value="0x02"/>
+      <value id="french"   value="0x03"/>
+      <value id="german"   value="0x04"/>
+      <value id="japanese" value="0x06"/>
+      <value id="portuguese_br" value="0x08"/>
+      <value id="russian"  valie="0x09"/>
+      <value id="spanish"  value="0x0a"/>
+      <value id="chinese"  valie="0x0d"/>
+    </control>
+    -->
+
+    <control id="dpms" address="0xd6">
+      <value id="on" value="1"/>
+      <value id="standby" value="4"/>
+      <value id="off" value="5"/>
+    </control>
+
+    <!-- this is inverted from VESA -->
+    <control id="power" type="list" address="0xe1">
+      <value id="on"  value="0"/>
+      <value id="standby" value="1"/>
+    </control>
+  </controls>
+
+  <include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA0A7.xml
+++ b/db/monitor/DELA0A7.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="DELL D3415W (mDP)" init="standard">
+  <!-- Include the DP interface from the same monitor. -->
+  <include file="DELA0A6"/>
+</monitor>

--- a/db/monitor/DELA0A8.xml
+++ b/db/monitor/DELA0A8.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="DELL D3415W (MHL)" init="standard">
+  <!-- Include the DP interface from the same monitor. -->
+  <include file="DELA0A6"/>
+</monitor>

--- a/db/monitor/DELA0AA.xml
+++ b/db/monitor/DELA0AA.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="DELL D3415W (HDMI)" init="standard">
+  <!-- Include the DP interface from the same monitor. -->
+  <include file="DELA0A6"/>
+</monitor>


### PR DESCRIPTION
Adds support for controlling as many things as I could decipher on my Dell U3415W monitor.

This is the output of the `LANG= LC_ALL= ddccontrol -p -c -d` command: [DELA0A8.txt](https://github.com/ddccontrol/ddccontrol-db/files/4672987/DELA0A8.txt)