### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.xml]
+indent_style = tab
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This ensures a common formatting standard is kept by everyone who opts in to use EditorConfig in their editors. I've spotted XML files with spaces instead of tabs, while most of the monitor definitions use tabs, and figured it would be best to add this.