### PR TITLE
Update build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Instructions for other distributions will be prepared later.
 Install build depedencies (on Ubuntu):
 
 ```shell
-sudo apt install intltool
+sudo apt install intltool libtool m4 automake autopoint
 ```
 
 Instructions for dependecies installation will be prepared later.


### PR DESCRIPTION
I got errors like `libtoolize: not found` and `autopoint: not found` when running `./autogen.sh` on a fresh Ubuntu 20.04 installation. Installing the dependencies added by this PR solved it.