### PR TITLE
Replace Secondary Degauss with New Control Value

### DIFF
--- a/db/monitor/ACR0692.xml
+++ b/db/monitor/ACR0692.xml
@@ -9,7 +9,7 @@
 	
 	<controls>
 	
-		<control id="secdegauss" address="0x02"/>
+		<control id="newcontrolvalue" address="0x02"/>
 		<control id="defaults" address="0x04" delay="2000"/>
 		<control id="defaultluma" address="0x05" delay="2000"/>
 		<control id="defaultcolor" address="0x08" delay="2000"/>
@@ -110,7 +110,6 @@
 		-->
 <!--
 Controls (valid/current/max) [Description - Value name]:
-Control 0x02: +/2/2 C [Secondary Degauss]
 Control 0x04: +/0/1 C [Restore Factory Defaults]
 Control 0x05: +/0/1 C [Restore Brightness and Contrast]
 Control 0x06: +/0/1   [???]

--- a/db/monitor/ACR06B1.xml
+++ b/db/monitor/ACR06B1.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0"?>
 <monitor name="Acer Nitro XV273K" init="standard">
-	<!--
-		The `add` attribute is the raw caps string from `sudo ddccontrol -c`, except that `02` has been removed from the `vcp()` part.
-		That modification AND the `remove` attribute are necessary to disable the VESA Degauss/secdegauss control, which XV273K (like all other non-CRTs) doesn't support.
-	-->
-	<caps add="(prot(monitor)type(lcd)model(XV273K)cmds(01 02 03 07 0C E3 F3)vcp(04 05 08 0B 0C 10 12 14(05 06 08 0B 0C) 16 18 1A 52 54(00 01) 59 5A 5B 5C 5D 5E 60(03 11 0F 10) 62 9B 9C 9D 9E 9F A0 AC AE B6 C0 C6 C8 C9 CC(01 02 03 04 05 06 08 09 0A 0C 0D 0E 14 16 1E)D6(01 04 05) DF E3 E5 E6 E7(00 01 02) E8(00 01 02) )mswhql(1)asset_eep(32)mccs_ver(2.1))" remove="(vcp(02))" />
+	<caps add="(prot(monitor)type(lcd)model(XV273K)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 0B 0C 10 12 14(05 06 08 0B 0C) 16 18 1A 52 54(00 01) 59 5A 5B 5C 5D 5E 60(03 11 0F 10) 62 9B 9C 9D 9E 9F A0 AC AE B6 C0 C6 C8 C9 CC(01 02 03 04 05 06 08 09 0A 0C 0D 0E 14 16 1E)D6(01 04 05) DF E3 E5 E6 E7(00 01 02) E8(00 01 02) )mswhql(1)asset_eep(32)mccs_ver(2.1))" />
 
 	<controls>
 		<control id="colorpreset" address="0x14">

--- a/db/monitor/DEL413A.xml
+++ b/db/monitor/DEL413A.xml
@@ -3,7 +3,7 @@
 	<caps add="(prot(monitor)type(LCD)model(U2518D)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C)16 18 1A 60(10 0F 11) AA(01 02 03 04) AC AE B6 C6 C8 C9 D6(01 04 05) DC(00 03 05) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) F0(0C) F1 F2 FD)mccs_ver(2.1)mswhql(1))"/>
 
 	<controls>
-		<control id="secdegauss" address="0x02" />
+		<control id="newcontrolvalue" address="0x02"/>
 
 		<control id="defaults" address="0x04" delay="2000"/>
 		<control id="defaultluma" address="0x05" delay="2000"/>

--- a/db/monitor/DELA0C3.xml
+++ b/db/monitor/DELA0C3.xml
@@ -40,11 +40,6 @@
 	mswhql(1)asset_eep(40)mccs_ver(2.1))
 -->
 	<controls>
-		<control id="newcontrolvalue" type="list" address="0x02">
-			<value id="nochanges" value="0x01"/>
-			<value id="changed" value="0x02"/>
-		</control>
-
 		<!-- not in vcp list -->
 		<!-- <control id="???" address="0x0b"/> -->
 

--- a/db/monitor/DELD0F.xml
+++ b/db/monitor/DELD0F.xml
@@ -2,7 +2,6 @@
 <monitor name="Dell S3220DGF" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(S3220DGF)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(05 08 0B 0C) 16 18 1A 52 60(0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CA CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 05 ) DF E0 E1 E2(00 20 21 22 2F 04 1E 1F 1D 0E 12 14 27 23 24 3A ) EA(FE00 FE01) F0(0D 0E 0C 0F 10 11 13 31 32 34 36 ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 	<controls>
-		<!-- Control 0x02: +/2/255 C [Secondary Degauss] -->
 		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
 		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
 		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->

--- a/db/monitor/GSM5807.xml
+++ b/db/monitor/GSM5807.xml
@@ -2,7 +2,7 @@
 <monitor name="LG IPS226V-PN" init="standard">
 	<caps add="(vcp(02 04 05 06 08 10 12 14(05 07 08 0B) 16 18 1a 87 D6(01 04) FC(00 01 02 03) FD(00 01) FE(00 01 02 03 04)))"/>
 	<controls>
-		<control id="secdegauss" address="0x02"/>
+		<control id="newcontrolvalue" address="0x02"/>
 
 		<!-- Control 0x03: +/0/65535 [???] -->
 			

--- a/db/monitor/VESA.xml
+++ b/db/monitor/VESA.xml
@@ -3,7 +3,10 @@
 <monitor name="VESA standard monitor" init="standard">
 	<controls>
 		<control id="degauss" address="0x00"/>
-		<control id="secdegauss" address="0x02"/>
+		<control id="newcontrolvalue" address="0x02">
+			<value id="nochanges" value="1"/>
+			<value id="changed" value="2"/>
+		</control>
 		
 		<control id="defaults" address="0x04" delay="2000"/>
 		<control id="defaultluma" address="0x05" delay="2000"/>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -452,7 +452,6 @@
 		</subgroup>
 		<subgroup name="Degauss">
 			<control id="degauss" type="command" name="Degauss" address="0x00"/>
-			<control id="secdegauss" type="command" name="Secondary Degauss" address="0x02"/>
 		</subgroup>
 		<subgroup name="OSD">
 			<control id="osd" type="list" name="On Screen Display" address="0x66"> <!--- USB specifies address 0xCA -->
@@ -494,9 +493,9 @@
 				<value id="brazilian"    name="Português do Brasil (Brazilian Portuguese)"/>
 			</control>
 			<!-- If "changed", read 0x52 register value to get address of the control changed using OSD menu -->
-			<control id="newcontrolvalue" type="list" name="New Control Value">
-				<value id="nochanges" name="No changes"/>
-				<value id="changed" name="Some values changed"/>
+			<control id="newcontrolvalue" type="list" name="New Control Value" address="0x02">
+				<value id="nochanges" name="No changes" value="0x01"/>
+				<value id="changed" name="Some values changed" value="0x02"/>
 			</control>
 		</subgroup>
 		<subgroup name="Power control">

--- a/doc/how-to-add-a-monitor.md
+++ b/doc/how-to-add-a-monitor.md
@@ -51,7 +51,7 @@ Modifying its name is probably the easiest way to verify that changes are applie
 +<monitor name="Cool unknown monitor" init="standard">
         <controls>
                 <control id="degauss" address="0x00"/>
-                <control id="secdegauss" address="0x02"/>
+                <control id="newcontrolvalue" address="0x02"/>
 ```
 
 Once you've made the change, install the database:
@@ -279,11 +279,8 @@ This fictional monitor would support controls at addresses `0x02`, `0x12`, `0x14
 
 ### Disabling controls
 
-Sometimes, a control may be displayed even though it's actually not supported.
-For example, the _VESA standard monitor_ profile includes degauss controls, which make sense for CRT monitors but not for LCDs.
-To prevent those from showing up in `ddccontrol -c` and the DDC Control GUI, you may need to explicitly disable them.
-
-For example, to disable the `secdegauss` control, which has address `0x02`:
+Sometimes, you may want to force-disable a control for one reason or another.
+For example, to disable the `newcontrolvalue` control, which has address `0x02`:
 
 ```diff
 --- a/db/monitor/ACR06B1.xml

--- a/doc/monitors/DELA0BE.md
+++ b/doc/monitors/DELA0BE.md
@@ -25,7 +25,6 @@ Parsed output:
 
 | Control | valid/current/max | Write test | Description                                      |
 | ------- | ----------------- | ---------- | ------------------------------------------------ |
-| 0x02    | +/2/2             |            | Secondary Degauss                                |
 | 0x04    | +/0/255           |            | Restore Factory Defaults                         |
 | 0x05    | +/0/1             | OK         | Restore Brightness and Contrast                  |
 | 0x06    | +/0/255           |            | ???                                              |

--- a/po/es.po
+++ b/po/es.po
@@ -862,8 +862,8 @@ msgstr "Degauss"
 
 #: ../../po/../db/options.xml.h:179
 #, c-format
-msgid "Secondary Degauss"
-msgstr "Degauss Secundario"
+msgid "New Control Value"
+msgstr "Nuevo valor de control"
 
 #: ../../po/../db/options.xml.h:180
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -826,8 +826,8 @@ msgstr "Démagnétiser"
 
 #: ../db/options.xml.h:168
 #, c-format
-msgid "Secondary Degauss"
-msgstr "Démagnétiser (contrôle secondaire)"
+msgid "New Control Value"
+msgstr "Nouvelle valeur de contrôle"
 
 #: ../db/options.xml.h:169
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -821,8 +821,8 @@ msgstr "Degauss"
 
 #: ../db/options.xml.h:168
 #, c-format
-msgid "Secondary Degauss"
-msgstr "Dodatkowy Degauss"
+msgid "New Control Value"
+msgstr "Nowa warto¶æ kontrolna"
 
 #: ../db/options.xml.h:169
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -818,8 +818,8 @@ msgstr "Размагничивание"
 
 #: ../db/options.xml.h:168
 #, c-format
-msgid "Secondary Degauss"
-msgstr "Вторичное размагничивание"
+msgid "New Control Value"
+msgstr "Новое контрольное значение"
 
 #: ../db/options.xml.h:169
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -818,8 +818,8 @@ msgstr "消磁"
 
 #: ../db/options.xml.h:168
 #, c-format
-msgid "Secondary Degauss"
-msgstr "二次消磁"
+msgid "New Control Value"
+msgstr "新控制值"
 
 #: ../db/options.xml.h:169
 #, c-format


### PR DESCRIPTION
As pointed out by @aqxa1 in #123, Secondary Degauss should never have
been included in the first place. It's not mentioned at all in
[MCCS][MCCS], which, on the contrary, _requires_ that monitors support
New Control Value at `0x02`.

Notably, degaussing is also meaningless for non-CRT monitors.

This PR essentially replaces the Secondary Degauss (`secdegauss`)
control with New Control Value (`newcontrolvalue`), updating individual
monitor definitions accordingly.

[MCCS]: https://milek7.pl/ddcbacklight/mccs.pdf