### PR TITLE
Add DELD072 alias for Dell U2515H

### DIFF
--- a/db/monitor/DELD072.xml
+++ b/db/monitor/DELD072.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2515H" init="standard">
+	<include file="DELD070"/>
+</monitor>


### PR DESCRIPTION
Output of `LANG= LC_ALL= ddccontrol -p -c -d` before adding:
```
ddccontrol version 0.4.4
Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
This program comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of this program under the terms of the GNU General Public License.

Probing for available monitorsradeon_open: mmap failed: Invalid argument
....I/O warning : failed to load external entity "/usr/share/ddccontrol-db/monitor/DELD072.xml"
Document not parsed successfully.
.I/O warning : failed to load external entity "/usr/share/ddccontrol-db/monitor/DELD072.xml"
Document not parsed successfully.
...
Detected monitors :
 - Device: dev:/dev/i2c-3
   DDC/CI supported: Yes
   Monitor Name: VESA standard monitor
   Input type: Digital
  (Automatically selected)
 - Device: dev:/dev/i2c-2
   DDC/CI supported: Yes
   Monitor Name: VESA standard monitor
   Input type: Digital
Reading EDID and initializing DDC/CI at bus dev:/dev/i2c-3...
I/O warning : failed to load external entity "/usr/share/ddccontrol-db/monitor/DELD072.xml"
Document not parsed successfully.

EDID readings:
	Plug and Play ID: DELD072 [VESA standard monitor]
	Input type: Digital
=============================== WARNING ===============================
There is no support for your monitor in the database, but ddccontrol is
using a basic generic profile. Many controls will not be supported, and
some controls may not work as expected.
Please update ddccontrol-db, or, if you are already using the latest
version, please send the output of the following command to
ddccontrol-users@lists.sourceforge.net:

LANG= LC_ALL= ddccontrol -p -c -d

Thank you.
=============================== WARNING ===============================

Capabilities:
Raw output: (prot(monitor)type(LCD)model(U2515H)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))
Parsed output: 
	VCP: 02 04 05 08 10 12 14 16 18 1a 52 60 aa ac ae b2 b6 c6 c8 c9 d6 dc df e0 e1 e2 f0 f1 f2 fd 
	Type: Unknown

Controls (valid/current/max) [Description - Value name]:
Control 0x02: +/2/2 C [Secondary Degauss]
Control 0x04: +/0/1 C [Restore Factory Defaults]
Control 0x05: +/0/1 C [Restore Brightness and Contrast]
Control 0x06: +/0/1   [???]
Control 0x08: +/0/1 C [Restore Factory Default Color]
Control 0x0b: +/100/0   [???]
Control 0x0e: +/100/0   [???]
Control 0x10: +/23/100 C [Brightness]
Control 0x12: +/50/100 C [Contrast]
Control 0x14: +/5/12 C [???]
Control 0x16: +/100/100 C [Red maximum level]
Control 0x18: +/100/100 C [Green maximum level]
Control 0x1a: +/100/100 C [Blue maximum level]
Control 0x1e: +/0/1   [???]
Control 0x1f: +/0/1   [???]
Control 0x20: +/0/1   [???]
Control 0x30: +/0/1   [???]
Control 0x3e: +/0/1   [???]
Control 0x52: +/242/255 C [???]
Control 0x60: +/18/18 C [Input Source Select (Main)]
Control 0x6c: +/18/18   [???]
Control 0x6e: +/18/18   [???]
Control 0x70: +/18/18   [???]
Control 0xaa: +/1/255 C [OSD Orientation - Landscape]
Control 0xac: +/6564/1 C [???]
Control 0xae: +/6010/65535 C [???]
Control 0xb2: +/1/1 C [???]
Control 0xb6: +/3/5 C [???]
Control 0xc0: +/1942/65535   [???]
Control 0xc6: +/17868/65535 C [???]
Control 0xc8: +/4361/17 C [???]
Control 0xc9: +/256/65535 C [???]
Control 0xca: +/1/2   [???]
Control 0xcc: +/2/11   [???]
Control 0xd6: +/1/5 C [DPMS Control - On]
Control 0xdc: +/0/5 C [???]
Control 0xdf: +/513/65535 C [???]
Control 0xe0: +/0/1 C [???]
Control 0xe1: +/0/1 C [Power control - Off]
Control 0xe2: +/0/25 C [???]
Control 0xf0: +/0/255 C [???]
Control 0xf1: +/3/255 C [???]
Control 0xf2: +/0/255 C [???]
Control 0xfc: +/0/255   [???]
Control 0xfd: +/99/255 C [???]
Invalid response, first byte is 0x82, should be 0x6e
82 01 fe 42 fd 00 00 ff 00 63 d5                | ...B.....c.     
Invalid response, first byte is 0x82, should be 0x6e
82 01 fe 42 fd 00 00 ff 00 63 d5                | ...B.....c.     
Invalid response, first byte is 0x82, should be 0x6e
82 01 fe 42 fd 00 00 ff 00 63 d5                | ...B.....c.     
```