### PR TITLE
Add DP interface of Iiyama GB3461WQSU

### DIFF
--- a/db/monitor/IVM7614.xml
+++ b/db/monitor/IVM7614.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="Iiyama GB3461WQSU" init="standard">
+<monitor name="Iiyama GB3461WQSU (HDMI)" init="standard">
 	<caps add="(prot(monitor)type(lcd)model(MN08070101)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 0B 0C 10 12 14(04 05 08 0B) 16 18 1A 52 60(00 11 12 0F 10 21 22 2F 30 31) 62 6C 6E 70 72(05 78 FB 50 64 78 8C A0) 86(01 02 08) 8D(01 02) A4 A5 AC AE B6 C0 C6 C8 C9 CA(01 02) CC(02 03 04 14 1E 12 05 09 06) D6(01 04 05) DC(00 01 02 03 05 08) DF E0(00 01 02 03 04) E9(00 02) EB(00 01 02 03) EC(00 01 02 03) EF(00 01 02 03 04 FF) F0(00 01) F6(01 ) F7(42 FF) FF)mswhql(1)asset_eep(40)mccs_ver(2.2))" />
 	<controls>
 		<control id="newcontrolvalue" address="0x02">

--- a/db/monitor/IVM7615.xml
+++ b/db/monitor/IVM7615.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="Iiyama GB3461WQSU (DP)" init="standard">
+  <!-- Include the HDMI interface from the same monitor. -->
+  <include file="IVM7614"/>
+</monitor>


### PR DESCRIPTION
I noticed that this monitor has a different ID when connected via DisplayPort, this adds an alias.