### PR TITLE
Fix Dell U3415W Uniformity Compensation control

### DIFF
--- a/db/monitor/DELA0A6.xml
+++ b/db/monitor/DELA0A6.xml
@@ -53,8 +53,8 @@
     </control>
     -->
 
-    <control id="coloruniformity" type="list" address="0xe4">
-      <value id="off" value="1"/>
+    <control id="uniformitycompensation" type="list" address="0xe4">
+      <value id="off" value="0"/>
       <value id="calibrated" value="1"/>
     </control>
 

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -270,6 +270,10 @@
 				<value id="off" name="Off"/>
 				<value id="calibrated" name="Calibrated"/>
 			</control>
+			<control id="uniformitycompensation" type="list" name="Uniformity Compensation">
+				<value id="off" name="Off"/>
+				<value id="calibrated" name="Calibrated"/>
+			</control>
 			<!-- DELL P2416D -->
 			<control id="dellpaper" type="command" name="Paper preset" address="0xf0">
 				<value id="set" value="0x08" name="Set Paper Preset"/>


### PR DESCRIPTION
* Uniformity Compensation can now be disabled.
* The label is now Uniformity Compensation instead of Color Uniformity,
matching the OSD (at least on my U3415W from week 15, 2015).