### PR TITLE
Improve Dell U2715H support

### DIFF
--- a/db/monitor/DELD065.xml
+++ b/db/monitor/DELD065.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <monitor name="Dell U2715H (DP)" init="standard">
 	<!-- Include the HDMI 2 interface from the same monitor. -->
-	<include file="DELD067"/>
+	<include file="DELD069"/>
 </monitor>

--- a/db/monitor/DELD065.xml
+++ b/db/monitor/DELD065.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2715H (DP)" init="standard">
+	<!-- Include the HDMI 2 interface from the same monitor. -->
+	<include file="DELD067"/>
+</monitor>

--- a/db/monitor/DELD067.xml
+++ b/db/monitor/DELD067.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <monitor name="Dell U2715H (HDMI 1)" init="standard">
 	<!-- Include the HDMI 2 interface from the same monitor. -->
-	<include file="DELD067"/>
+	<include file="DELD069"/>
 </monitor>

--- a/db/monitor/DELD067.xml
+++ b/db/monitor/DELD067.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2715H (HDMI 1)" init="standard">
+	<!-- Include the HDMI 2 interface from the same monitor. -->
+	<include file="DELD067"/>
+</monitor>

--- a/db/monitor/DELD069.xml
+++ b/db/monitor/DELD069.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="Dell U2715H" init="standard">
+<monitor name="Dell U2715H (HDMI 2)" init="standard">
    <caps add="(prot(monitor)type(LCD)model(U2715H)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))" />
    <controls>
         <control id="inputsource" type="list" address="0x60">
@@ -7,6 +7,13 @@
             <value id="mdp" value="0x10"/>
             <value id="hdmi1" value="0x11"/>
             <value id="hdmi2" value="0x12"/>
+        </control>
+
+        <!-- Seems to be read-only. At least, writing using `ddccontrol -w` does not change it. -->
+        <control id="osdorientation" type="list" address="0xaa">
+            <value id="landscape" value="0x01"/>
+            <value id="portraitright" value="0x02"/>
+            <value id="portraitleft" value="0x04"/>
         </control>
    </controls>
    <include file="VESA"/>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -470,6 +470,8 @@
 			<control id="osdorientation" type="list" name="OSD Orientation" address="0xaa">
 				<value id="landscape" name="Landscape"/>
 				<value id="portrait" name="Portrait"/>
+				<value id="portraitleft" name="Portrait (Left)"/>
+				<value id="portraitright" name="Portrait (Right)"/>
 			</control>
 			<control id="language" type="list" name="Language select" address="0x68">
 				<value id="english"       name="English"/>


### PR DESCRIPTION
This PR adds support for U2715H over DP and HDMI 1 (but not mDP, because
I currently don't have an mDP cable available).