### PR TITLE
Normalize DELL to Dell

### DIFF
--- a/db/monitor/DEL4063.xml
+++ b/db/monitor/DEL4063.xml
@@ -34,7 +34,7 @@
       <value id="off" value="5"/>
     </control>
 
-    <!--- DELL u3011 controls -->
+    <!--- Dell u3011 controls -->
     <control id="colorpreset" address="0x14">
       <value id="srgb"  value="0x01"/>
       <value id="native"  value="0x05"/>

--- a/db/monitor/DEL5000.xml
+++ b/db/monitor/DEL5000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL P1130" init="standard">
+<monitor name="Dell P1130" init="standard">
 	<!--- CAPS: (prot(monitor) type(crt) model(DEL0050 ) edid bin(128
 	(################################################################################################################################))cmds(01 02 03 04 05 06 0C)
 	vcp(00 01 04 06 08 10 12 14 16 18 1A 20 22 24 26 28 30 32 38 40 42 44 54 56 68 6C 6E 70 E0 E2 F1 F2 F3 F4 F5 F6 F7)) -->

--- a/db/monitor/DEL50AB.xml
+++ b/db/monitor/DEL50AB.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!--- File provided by Grzegorz Kurtyka -->
-<!---DELL P1100 is a CRT. CAPS invalid
+<!---Dell P1100 is a CRT. CAPS invalid
 (prot(monitor)  type(crt) model( DELAB50           edid bin(128(################################################################################################################################))cmds(01020304050608090A0B0C4F)vcp(00010810121416181A20222426283032384042445456686C6E70E0E2F1F2F3F4F5F6F7)
 -->
-<monitor name="DELL P1100" init="standard">
+<monitor name="Dell P1100" init="standard">
 	<include file="SUN0577"/>
 	<controls>
 	    <control id="autosize" address="0xe0" />

--- a/db/monitor/DELA0A6.xml
+++ b/db/monitor/DELA0A6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL D3415W (DP)" init="standard">
+<monitor name="Dell D3415W (DP)" init="standard">
   <!-- original caps -->
   <caps add="(prot(monitor)type(LCD)model(U3415)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) E4(00 01) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 

--- a/db/monitor/DELA0A7.xml
+++ b/db/monitor/DELA0A7.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL D3415W (mDP)" init="standard">
+<monitor name="Dell D3415W (mDP)" init="standard">
   <!-- Include the DP interface from the same monitor. -->
   <include file="DELA0A6"/>
 </monitor>

--- a/db/monitor/DELA0A8.xml
+++ b/db/monitor/DELA0A8.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL D3415W (MHL)" init="standard">
+<monitor name="Dell D3415W (MHL)" init="standard">
   <!-- Include the DP interface from the same monitor. -->
   <include file="DELA0A6"/>
 </monitor>

--- a/db/monitor/DELA0AA.xml
+++ b/db/monitor/DELA0AA.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL D3415W (HDMI)" init="standard">
+<monitor name="Dell D3415W (HDMI)" init="standard">
   <!-- Include the DP interface from the same monitor. -->
   <include file="DELA0A6"/>
 </monitor>

--- a/db/monitor/DELA0C2.xml
+++ b/db/monitor/DELA0C2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL P2416D (VGA)" init="standard">
+<monitor name="Dell P2416D (VGA)" init="standard">
 	<!--- <caps add="(prot(monitor)type(LCD)model(P2416D)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 06 08 0E 10 12 14(05 08 0B 0C) 16 18 1A 1E 20 30 3E 52 60(01 11 0F) AA(01 02) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 0E 12 14 19) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/> -->
 	<include file="DELA0C3"/>
 </monitor>

--- a/db/monitor/DELA0C3.xml
+++ b/db/monitor/DELA0C3.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<monitor name="DELL P2416D" init="standard">
+<monitor name="Dell P2416D" init="standard">
 	<!-- <caps add="(prot(monitor)type(LCD)model(P2416D)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(05 08 0B 0C) 16 18 1A 52 60(01 11 0F) AA(01 02) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 0E 12 14 19) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/> -->
 <!--
 	Probed through VGA bus (responds as DELA0C2) reports a bit more controls
 	than through HDMI bus (responds as DELA0C3).
-	Likely may be generalized to MCCS 2.1 at least for DELL monitors:
+	Likely may be generalized to MCCS 2.1 at least for Dell monitors:
 
 	DELA09B (DVI)
 	(prot(monitor)type(LCD)model(P2414H)

--- a/db/monitor/DELA0EF.xml
+++ b/db/monitor/DELA0EF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI1 1.4 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI1 1.4)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via HDMI1 1.4 (reports a different EDID) -->
+<monitor name="Dell U3818DW (HDMI1 1.4)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F0.xml
+++ b/db/monitor/DELA0F0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI1 2.0 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI1 2.0)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via HDMI1 2.0 (reports a different EDID) -->
+<monitor name="Dell U3818DW (HDMI1 2.0)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F1.xml
+++ b/db/monitor/DELA0F1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 1.4 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI2 1.4)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via HDMI2 1.4 (reports a different EDID) -->
+<monitor name="Dell U3818DW (HDMI2 1.4)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F2.xml
+++ b/db/monitor/DELA0F2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via HDMI2 2.0 (reports a different EDID) -->
-<monitor name="DELL U3818DW (HDMI2 2.0)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via HDMI2 2.0 (reports a different EDID) -->
+<monitor name="Dell U3818DW (HDMI2 2.0)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA0F3.xml
+++ b/db/monitor/DELA0F3.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via DisplayPort -->
-<monitor name="DELL U3818DW (DisplayPort)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via DisplayPort -->
+<monitor name="Dell U3818DW (DisplayPort)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
-	<!-- Vendor-specific controls for the DELL monitor -->
+	<!-- Vendor-specific controls for the Dell monitor -->
 	<controls>
 		<control id="PbP" type="list" address="0xe9">
 			<value id="Off"		value="0x00"/>

--- a/db/monitor/DELA0F4.xml
+++ b/db/monitor/DELA0F4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!-- DELL UltraSharp 38 Monitor (Model 2017) via USB Type-C (reports a different EDID) -->
-<monitor name="DELL U3818DW (USB Type-C)" init="standard">
+<!-- Dell UltraSharp 38 Monitor (Model 2017) via USB Type-C (reports a different EDID) -->
+<monitor name="Dell U3818DW (USB Type-C)" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(U3818DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 12 ) 62 AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14) E4(00 01) E5 E7(00 01 02) E8 E9(00 21 22 24 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
 
 	<!-- use the settings from the DisplayPort version of the monitor -->

--- a/db/monitor/DELA125.xml
+++ b/db/monitor/DELA125.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<monitor name="DELL U3219Q" init="standard">
+<monitor name="Dell U3219Q" init="standard">
        <caps add="(prot(monitor)type(LCD)model(U3219Q)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 ) AA(01 02 04 ) AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0C 0D 0F 10 11 13 14 27 23 24 28 ) E4(00 01) E5 E7(00 02) E8 E9(00 21 22 24 ) EA(FE00 FE01FC01 FC02) F0(0C 31 32 34 35 ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))" />
        <include file="VESA"/>
        <control id="inputsource" type="list" address="0x60">

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -270,7 +270,7 @@
 				<value id="off" name="Off"/>
 				<value id="calibrated" name="Calibrated"/>
 			</control>
-			<!-- DELL P2416D -->
+			<!-- Dell P2416D -->
 			<control id="dellpaper" type="command" name="Paper preset" address="0xf0">
 				<value id="set" value="0x08" name="Set Paper Preset"/>
 			</control>

--- a/doc/monitors/DELA0C3.md
+++ b/doc/monitors/DELA0C3.md
@@ -1,4 +1,4 @@
-# DELL P2416D: DELA0C2 (VGA), DELA0C3 (HDMI)
+# Dell P2416D: DELA0C2 (VGA), DELA0C3 (HDMI)
 
 EDID readings:
 	Plug and Play ID: DELA0C2 [VESA standard monitor]


### PR DESCRIPTION
The Internet, including Dell themselves, seems to unanimously agree on
the "Dell" spelling.

https://www.google.com/search?q=dell