### PR TITLE
Add Dell Ultrasharp U2721DE (PnP ID: DEL41E0)

### DIFF
--- a/db/monitor/DEL41E0.xml
+++ b/db/monitor/DEL41E0.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2721DE" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U2721DE)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(1B 0F 11 ) AA(01 02 03 04 ) AC AE B2 B6 C6 C8 C9 CA CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 29 02 04 0C 0D 0F 10 11 13 14 ) E3(16 17 18 19 1A) F0(0C 12 ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))" />
+	<controls>
+		<control id="newcontrolvalue" address="0x02">
+			<value id="nochanges" value="1"/>
+			<value id="changed" value="2"/>
+		</control>
+
+		<control id="defaults" address="0x04" delay="2000"/>
+		<control id="defaultluma" address="0x05" delay="2000"/>
+		<control id="defaultcolor" address="0x08" delay="2000"/>
+
+		<control id="brightness" address="0x10"/>
+		<control id="contrast" address="0x12"/>
+
+		<control id="inputsource" type="list" address="0x60">
+			<value id="usb-c" value="0x1b"/>
+			<value id="dp" value="0x0f"/>
+			<value id="hdmi" value="0x11"/>
+		</control>
+
+		<control id="colorpreset" address="0x14">
+			<value id="normal" value="0x00"/>
+			<value id="5000k" value="0x04"/>
+			<value id="5700k" value="0x0B"/>
+			<value id="6500k" value="0x05"/>
+			<value id="7500k" value="0x06"/>
+			<value id="9300k" value="0x08"/>
+			<value id="10000k" value="0x09"/>
+			<value id="user" value="0x0C"/>
+			<value id="standard" value="0x00"/>
+			<value id="movie" value="0x03"/>
+			<value id="game" value="0x05"/>
+			<!-- multiscreen match is also an option on the OSD -->
+		</control>
+
+		<control id="red" address="0x16"/>
+		<control id="green" address="0x18"/>
+		<control id="blue" address="0x1A"/>
+
+		<control id="osdorientation" type="list" address="0xaa">
+			<value id="landscape" value="1"/>
+			<value id="portrait" value="2"/>
+		</control>
+
+		<control id="language" type="list" address="0xcc">
+			<value id="english" value="0x02"/>
+			<value id="spanish" value="0x0a"/>
+			<value id="french" value="0x03"/>
+			<value id="german" value="0x04"/>
+			<value id="brazilian" value="0x0e"/>
+			<value id="russian" value="0x09"/>
+			<value id="chinese" value="0x0d"/>
+			<value id="japanese" value="0x06"/>
+		</control>
+
+		<control id="power" type="list" address="0xe1">
+			<value id="on" value="0"/>
+			<value id="off" value="1"/>
+		</control>
+	</controls>
+</monitor>

--- a/db/monitor/DEL41E0.xml
+++ b/db/monitor/DEL41E0.xml
@@ -21,7 +21,6 @@
 		</control>
 
 		<control id="colorpreset" address="0x14">
-			<value id="normal" value="0x00"/>
 			<value id="5000k" value="0x04"/>
 			<value id="5700k" value="0x0B"/>
 			<value id="6500k" value="0x05"/>
@@ -29,10 +28,12 @@
 			<value id="9300k" value="0x08"/>
 			<value id="10000k" value="0x09"/>
 			<value id="user" value="0x0C"/>
+		</control>
+
+		<control id="magicbright" address="0xdc">
 			<value id="standard" value="0x00"/>
 			<value id="movie" value="0x03"/>
 			<value id="game" value="0x05"/>
-			<!-- multiscreen match is also an option on the OSD -->
 		</control>
 
 		<control id="red" address="0x16"/>


### PR DESCRIPTION
Add https://www.dell.com/support/home/en-us/product-support/product/dell-u2721de-monitor/overview

_The same file can probably be used for U2421HE but we will need to find it monitor PnP ID._