### PR TITLE
WIP: Add Iiyama PL2730H

### DIFF
--- a/db/monitor/IVM663A.xml
+++ b/db/monitor/IVM663A.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<monitor name="Iiyama PL2730H" init="standard">
+        <controls>
+                <control id="dynamiccontrast" type="list" address="0xfb">
+                        <value id="off" value="0x00"/>
+                        <value id="on" value="0x01"/>
+                </control>
+                <control id="colorpreset" type="list" address="0x14">
+                        <value id="cool" value="0x08"/>
+                        <value id="normal" value="0x06"/>
+                        <value id="warm" value="0x05"/>
+                        <value id="custom" value="0xb"/>
+                </control>
+                <control id="inputsource" type="list" address="0x60">
+                        <value id="vga"  value="0x00"/>
+                        <value id="hdmi" value="0x11"/>
+                        <value id="dp" value="0xf"/>
+                </control>
+                <control id="language" type="list" address="0xcc">
+                        <value id="english" value="0x02"/>
+                        <value id="french" value="0x03"/>
+                        <value id="german" value="0x04"/>
+                        <value id="italian" value="0x05"/>
+                        <value id="polish" value="0x1e"/>
+                        <value id="spanish" value="0xa"/>
+                        <value id="dutch" value="0x14"/>
+                        <value id="czech" value="0x12"/>
+                        <value id="russian" value="0x09"/>
+                        <value id="japanese" value="0x06"/>
+                        <value id="chinese" value="0xd"/>
+                </control>
+        </controls>
+        <include file="VESA"/>
+</monitor>


### PR DESCRIPTION
I do have a question about the caps string. In the documentation there is a command with the option `-c` the get the raw caps string but using it I only get:

```
Capabilities:
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
Capabilities read fail.
```
Is this capability string something you have to manually create? If so I will try to add a caps string before merging.

Also by probing with `-d` I found that some changes are not reflected by changes in the range the command probes, could this be something vendor specific outside the range? And if so what would be the best way to probe for this ranges too?

And last but not least. I was tired diffing probe results so i wrote a small bash program to help me with that if you want I can create a PR to add a link or the file itself to the documentation.
https://gist.github.com/Munsio/eaf93e48edcffb57827a8d35284167b8