### PR TITLE
Monitor LG 32UL950-W

### DIFF
--- a/db/monitor/GSM7706.xml
+++ b/db/monitor/GSM7706.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<monitor name="LG 32UL950-W" init="standard">
+    <caps add="(prot(monitor)type(lcd)model(UL950)cmds(01 02 03 0C E3 F3)vcp(02 04 05 08 10 12 14(05 08 0B ) 16 18 1A 52 60(11 0F ) AC AE B2 B6 C0 C6 C8 C9 D6(01 04) DF 62 8D F4 F5(01 02 03 04) F6(00 01 02) 4D 4E 4F 15(01 06 11 13 14 15 18 19 20 22 23 24 28 29 32 48) F7(00 01 02 03) F8(00 01) F9 E4 E5 E6 E7 E8 E9 EA EB EF FA(00 01) FD(00 01) FE(00 01 02) FF)mccs_ver(2.1)mswhql(1))" />
+    <controls>
+        <!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+        <control id="newcontrolvalue" address="0x02"/>
+        <!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+        <control id="defaults" address="0x04" delay="2000"/>
+        <!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+        <control id="defaultluma" address="0x05" delay="2000"/>
+        <!-- Control 0x06: +/0/255   [???] -->
+        <control id="defaultgeom" address="0x06" delay="2000"/>
+        <!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+        <control id="defaultcolor" address="0x08" delay="2000"/>
+        <!-- Control 0x10: +/28/100 C [Brightness] -->
+        <control id="brightness" address="0x10"/>
+        <!-- Control 0x12: +/60/100 C [Contrast] -->
+		<control id="contrast" address="0x12"/>
+        <!-- Control 0x87: +/60/100   [Sharpness] -->
+        <control id="sharpness" address="0x87"/>
+        <!-- Control 0x14: +/5/11 C [???] -->
+		<control id="colorpreset" address="0x14">
+			<value id="user" value="0x0B"/>
+			<value id="6500k" value="0x05"/>
+			<value id="9300k" value="0x08"/>
+		</control>
+        <!-- Control 0x0c: +/50/100 C [Color temperature request] ? -->
+        <control id="colortemp" address="0x0c"/>
+        <!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<control id="red" address="0x16"/>
+        <!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<control id="green" address="0x18"/>
+        <!-- Control 0x1a: +/39/100 C [Blue maximum level] -->
+		<control id="blue" address="0x1a"/>
+        <!-- Control 0x62: +/77/100 C [Audio Speaker Volume Adjust] -->
+        <control id="audiospeakervolume" address="0x62"/>
+        <!-- Control: 0x8d [Audio Mute] -->
+        <control id="audiospeakermute" address="0x8d">
+			<value id="mute" value="1"/>
+			<value id="unmute" value="2"/>
+		</control>
+        <!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<control id="dpms" address="0xd6">
+			<value id="on" value="1"/>
+			<value id="standby" value="5"/>
+		</control>
+        <!-- Control 0xf7: +/2/255 C [Response time] -->
+        <control id="responsetime" address="0xF7">
+            <value id="off" value="0"/>
+            <value id="high" value="1"/>
+            <value id="middle" value="2"/>
+            <value id="low" value="3"/>
+        </control>
+        <!-- Control 0xf8: +/0/255 C [Free Sync] -->
+        <control id="freesync" address="0xF8">
+            <value id="off" value="0"/>
+            <value id="base" value="2"/>
+            <value id="extended" value="3"/>
+        </control>
+        <!-- Control 0xf9: +/0/255 C [Black Stabilization] - Cannot write ? -->
+        <control id="blackstabilization" address="0xf9" />
+        <!-- Control 0xfe: +/2/255 C [Gamma]  - Cannot write ? -->
+        <control id="gammamode" address="0xfe" >
+			<value id="mode1" value="2" />
+			<value id="mode2" value="3" />
+			<value id="mode3" value="4" />
+			<value id="mode4" value="16" />
+		</control>
+    </controls>
+</monitor>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -5,7 +5,7 @@
 			<control id="brightness" type="value" name="Brightness" address="0x10"/>
 			<control id="contrast" type="value" name="Contrast" address="0x12"/>
 			<!--- vendor specific controls -->
-			<control id="sharpness" type="value" name="Sharpness" address="0x87"/>
+			<control id="sharpness" type="value" name="Sharpness"/>
 			<control id="dynamiccontrast" type="list" name="Dynamic Contrast">
 				<value id="off" name="Off"/>
 				<value id="on" name="On"/>
@@ -178,13 +178,13 @@
 				<value id="2.4" name="2.4"/>
 				<value id="2.6" name="2.6"/>
 			</control>
+			<control id="gammamode" type="list" name="Gamma" address="0xfe" >
+				<value id="mode1" name="Mode 1"/>
+				<value id="mode2" name="Mode 2"/>
+				<value id="mode3" name="Mode 3"/>
+				<value id="mode4" name="Mode 4"/>
+			</control>
 		</subgroup>
-		<control id="gammamode" type="list" name="Gamma" address="0xfe" >
-			<value id="mode1" name="Mode 1"/>
-			<value id="mode2" name="Mode 2"/>
-			<value id="mode3" name="Mode 3"/>
-			<value id="mode4" name="Mode 4"/>
-		</control>
 		<subgroup name="Color maximum level">
 			<control id="red" type="value" name="Red maximum level" address="0x16"/>
 			<control id="green" type="value" name="Green maximum level" address="0x18"/>
@@ -265,7 +265,7 @@
 				<!-- ACR06B1 -->
 				<value id="bluelight" name="Blue Light"/>
 			</control>
-			<control id="colortemp" type="value" name="Color Temperature Request" address="0x0c"/>
+			<control id="colortemp" type="value" name="Color Temperature Request"/>
 			<control id="magiccolor" type="list" name="MagicColor" address="0xF0">
 				<value id="off" name="Off"/>
 				<value id="demo" name="Demo"/>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -5,6 +5,7 @@
 			<control id="brightness" type="value" name="Brightness" address="0x10"/>
 			<control id="contrast" type="value" name="Contrast" address="0x12"/>
 			<!--- vendor specific controls -->
+			<control id="sharpness" type="value" name="Sharpness" address="0x87"/>
 			<control id="dynamiccontrast" type="list" name="Dynamic Contrast">
 				<value id="off" name="Off"/>
 				<value id="on" name="On"/>
@@ -178,6 +179,12 @@
 				<value id="2.6" name="2.6"/>
 			</control>
 		</subgroup>
+		<control id="gammamode" type="list" name="Gamma" address="0xfe" >
+			<value id="mode1" name="Mode 1"/>
+			<value id="mode2" name="Mode 2"/>
+			<value id="mode3" name="Mode 3"/>
+			<value id="mode4" name="Mode 4"/>
+		</control>
 		<subgroup name="Color maximum level">
 			<control id="red" type="value" name="Red maximum level" address="0x16"/>
 			<control id="green" type="value" name="Green maximum level" address="0x18"/>
@@ -258,6 +265,7 @@
 				<!-- ACR06B1 -->
 				<value id="bluelight" name="Blue Light"/>
 			</control>
+			<control id="colortemp" type="value" name="Color Temperature Request" address="0x0c"/>
 			<control id="magiccolor" type="list" name="MagicColor" address="0xF0">
 				<value id="off" name="Off"/>
 				<value id="demo" name="Demo"/>
@@ -560,6 +568,8 @@
 			<control id="freesync" type="list" name="FreeSync" address="0xF8">
 				<value id="off" name="Off" value="0"/>
 				<value id="on" name="On" value="1"/>
+				<value id="base" name="Base" value="2"/>
+				<value id="extended" name="Extended" value="3"/>
 			</control>
 			<control id="responsetime" type="list" name="Response Time" address="0xF7">
 				<value id="off" name="Off" value="0"/>
@@ -567,6 +577,7 @@
 				<value id="middle" name="Middle" value="2"/>
 				<value id="low" name="Low" value="3"/>
 			</control>
+			<control id="blackstabilization" type="value" name="Black Stabilization" address="0xf9" />
 		</subgroup>
 	</group>
 </options>


### PR DESCRIPTION
### Added the monitor LG 32UL950-W (GSM7706)

Two of the controls does not work as expected: I can read the values configured via the monitor OSD, but I cannot write them:

```XML
        <!-- Control 0xf9: +/0/255 C [Black Stabilization] - Cannot write ? -->
        <control id="blackstabilization" address="0xf9" />
        <!-- Control 0xfe: +/2/255 C [Gamma]  - Cannot write ? -->
        <control id="gammamode" address="0xfe" >
```

I'll appreciate your suggestions.
