### PR TITLE
Added U2719D

### DIFF
--- a/db/monitor/DEL415A.xml
+++ b/db/monitor/DEL415A.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<monitor name="Dell UltraSharp U2719D" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U2719D)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C)16 18 1A 60(10 0F 11) AA(01 02 03 04) AC AE B6 CA(01 02) C6 C8 C9 D6(01 04 05) DC(00 03 05) DF E0 E1 E2(00 02 04 0F 14 1D 29) F0(0C) F1 F2 FD)mccs_ver(2.1)mswhql(1))"/>
+
+	<controls>
+		<control id="newcontrolvalue" address="0x02"/>
+
+		<control id="defaults" address="0x04" delay="2000"/>
+		<control id="defaultluma" address="0x05" delay="2000"/>
+		<control id="defaultcolor" address="0x08" delay="2000"/>
+
+		<control id="brightness" address="0x10"/>
+		<control id="contrast" address="0x12"/>
+
+		<control id="colorpreset" address="0x14">
+			<value id="normal" value="0x00"/>
+			<value id="5000k" value="0x04"/>
+			<value id="5700k" value="0x0B"/>
+			<value id="6500k" value="0x05"/>
+			<value id="7500k" value="0x06"/>
+			<value id="9300k" value="0x08"/>
+			<value id="10000k" value="0x09"/>
+			<value id="user" value="0x0C"/>
+			<value id="comfort" value="0x0D"/>
+		</control>
+
+		<control id="red" address="0x16"/>
+		<control id="green" address="0x18"/>
+		<control id="blue" address="0x1A"/>
+
+		<!-- Control 0x52: +/20/65535 -->
+		<!-- Control 0x5c: +/0/65535 -->
+
+		<control id="inputsource" type="list" address="0x60">
+			<value id="dp" value="0x0F"/>
+			<value id="mdp" value="0x10"/>
+			<value id="hdmi" value="0x11"/>
+		</control>
+
+		<control id="redblack" address="0x6c"/>
+		<control id="greenblack" address="0x6e"/>
+		<control id="blueblack" address="0x70"/>
+
+
+		<control id="osdorientation" address="0xaa">
+			<value id="landscape" value="1"/>
+			<value id="portrait-cw" value="2"/>
+			<value id="landscape-180" value="3"/>
+			<value id="portrait-ccw" value="4"/>
+		</control>
+
+		<!-- Control 0xac: +/23364/1 C [???]	-->
+		<!-- Control 0xae: +/6000/0 C [???] 	-->
+		<!-- Control 0xb2: +/3/8   [???]    	-->
+		<!-- Control 0xb6: +/3/65535 C [???]	-->
+
+		<control id="colorformat" address="0xca"><!-- Determines the Colour format: readonly -->
+			<value id="RGB" value="1"/>
+			<value id="YPbPr" value="2"/>
+		</control>
+
+		<!-- Control 0xc6: +/17868/65535 C [???]-->
+		<!-- Control 0xc8: +/22021/0 C [???]	-->
+		<!-- Control 0xc9: +/513/65535 C [???]	-->
+
+		<control id="dpms" address="0xd6">
+			<value id="on" value="1"/>
+			<value id="standby" value="4"/> <!-- Behavior seems same as off -->
+			<value id="off" value="5"/>
+		</control>
+
+
+		<control id="magicbright" address="0xdc">
+			<value id="standard"  value="0x00"/>
+			<value id="movie"  value="0x03"/>
+			<value id="game" value="0x05"/>
+		</control>
+
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+
+		<control id="power" type="list" address="0xe1">
+			<value id="off" value="1"/>
+			<value id="on"  value="0"/>
+		</control>
+
+		<control id="presetmodes" type="list" address="0xe2"><!-- Indicates what preset is selected: readonly -->
+			<value id="Standard" value="0"/>
+			<value id="Movie" value="2"/>
+			<value id="Game" value="4"/>
+			<value id="Color Temp" value="15"/>
+			<value id="Custom Color" value="20"/>
+			<value id="ComfortView" value="29"/>
+			<value id="Multiscreen Match" value="41"/>
+		</control>
+
+		<!-- Control 0xf0: +/0/65535 C [???]  -->
+		<!-- Control 0xf1: +/139/65535 C [???]  -->
+		<!-- Control 0xf2: +/0/65535 C [???]  -->
+		<!-- Control 0xfd: +/116/65535 C [???]  -->
+
+
+	</controls>
+</monitor>

--- a/db/monitor/DEL415A.xml
+++ b/db/monitor/DEL415A.xml
@@ -44,9 +44,9 @@
 
 		<control id="osdorientation" address="0xaa">
 			<value id="landscape" value="1"/>
-			<value id="portrait-cw" value="2"/>
-			<value id="landscape-180" value="3"/>
-			<value id="portrait-ccw" value="4"/>
+			<value id="portraitleft" value="2"/>
+			<value id="landscape180" value="3"/>
+			<value id="portraitright" value="4"/>
 		</control>
 
 		<!-- Control 0xac: +/23364/1 C [???]	-->
@@ -54,10 +54,12 @@
 		<!-- Control 0xb2: +/3/8   [???]    	-->
 		<!-- Control 0xb6: +/3/65535 C [???]	-->
 
-		<control id="colorformat" address="0xca"><!-- Determines the Colour format: readonly -->
+		<!-- Determines the Colour format: readonly
+		<control id="colorformat" address="0xca">
 			<value id="RGB" value="1"/>
 			<value id="YPbPr" value="2"/>
 		</control>
+		-->
 
 		<!-- Control 0xc6: +/17868/65535 C [???]-->
 		<!-- Control 0xc8: +/22021/0 C [???]	-->
@@ -84,7 +86,8 @@
 			<value id="on"  value="0"/>
 		</control>
 
-		<control id="presetmodes" type="list" address="0xe2"><!-- Indicates what preset is selected: readonly -->
+		<!-- Indicates what preset is selected: readonly
+		<control id="presetmodes" type="list" address="0xe2">
 			<value id="Standard" value="0"/>
 			<value id="Movie" value="2"/>
 			<value id="Game" value="4"/>
@@ -93,6 +96,7 @@
 			<value id="ComfortView" value="29"/>
 			<value id="Multiscreen Match" value="41"/>
 		</control>
+		-->
 
 		<!-- Control 0xf0: +/0/65535 C [???]  -->
 		<!-- Control 0xf1: +/139/65535 C [???]  -->


### PR DESCRIPTION
So this monitor is very similar to the `U2518D`

I found some controls that reflect some settings in the on-screen-display but they are readonly, not sure if the info is useful or not but I included it anyway.

I've tested the majority of these settings and they all seem to work. On/Off, Input selection works fine. colorpreset sort of works albeit you cannot set the colour back to normal as that doesn't seem to work.

Anything else I've missed?