### PR TITLE
Add support for LG Ultrafine 4K (24MD4KL-B)

### DIFF
--- a/db/monitor/GSM5B7B.xml
+++ b/db/monitor/GSM5B7B.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<monitor name="LG UltraFine 24MD4KL-B" init="standard">
+	<caps add="(vcp(10))" />
+	<controls>
+		<control id="brightness" address="0x10" />
+	</controls>
+</monitor>


### PR DESCRIPTION
Failed to read capabilities, but managed to add brightness control manually

```
ddccontrol version 0.6.0
Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
This program comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of this program under the terms of the GNU General Public License.

Detected monitors :
 - Device: dev:/dev/i2c-6
   DDC/CI supported: Yes
   Monitor Name: LG UltraFine 24MD4KL-B
   Input type: Digital
  (Automatically selected)
 - Device: dev:/dev/i2c-5
   DDC/CI supported: Yes
   Monitor Name: VESA standard monitor
   Input type: Digital
Reading EDID and initializing DDC/CI at bus dev:/dev/i2c-6...

EDID readings:
	Plug and Play ID: GSM5B7B [LG UltraFine 24MD4KL-B]
	Input type: Analog

Capabilities:
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
Capabilities read fail.

Controls (valid/current/max) [Description - Value name]:
Control 0x02: +/1/2   [???]
Control 0x10: +/100/100 C [Brightness]
Control 0xc9: +/769/65535   [???]
Control 0xd2: +/3840/65535   [???]
Control 0xd3: +/2160/65535   [???]
Control 0xd5: +/60/65535   [???]
Control 0xdd: +/0/255   [???]
Control 0xfb: +/2/2   [???]
```