### PR TITLE
Add definitions for Dell U4919DW.

### DIFF
--- a/db/monitor/DELA107.xml
+++ b/db/monitor/DELA107.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (HDMI-1)" init="standard">
+	<include file="U4919DW" />
+</monitor>

--- a/db/monitor/DELA109.xml
+++ b/db/monitor/DELA109.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (HDMI-2)" init="standard">
+	<include file="U4919DW" />
+</monitor>

--- a/db/monitor/DELA10A.xml
+++ b/db/monitor/DELA10A.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (HDMI-1, PBP)" init="standard">
+	<include file="U4919DW" />
+</monitor>

--- a/db/monitor/DELA10B.xml
+++ b/db/monitor/DELA10B.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (HDMI-2, PBP)" init="standard">
+	<include file="U4919DW" />
+</monitor>

--- a/db/monitor/DELA10D.xml
+++ b/db/monitor/DELA10D.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (DisplayPort)" init="standard">
+	<include file="U4919DW"/>
+</monitor>

--- a/db/monitor/DELA10E.xml
+++ b/db/monitor/DELA10E.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="DELL U4919DW (DisplayPort)" init="standard">
+	<include file="U4919DW" />
+</monitor>

--- a/db/monitor/DELA10F.xml
+++ b/db/monitor/DELA10F.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (USB-C)" init="standard">
+	<include file="U4919DW"/>
+</monitor>

--- a/db/monitor/DELA111.xml
+++ b/db/monitor/DELA111.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U4919DW (USB-C, PBP)" init="standard">
+	<include file="U4919DW"/>
+</monitor>

--- a/db/monitor/U4919DW.xml
+++ b/db/monitor/U4919DW.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<monitor name="DELL U4919DW" init="standard" >
+	<caps add="prot(monitor)type(lcd)model(U4919DW)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 05 06 08 09 0B 0C) 16 18 1A 52 60(11 12 1B 0F) AC AE B2 B6 C6 C8 C9 CC(02 03 04 06 09 0A 0D 0E) D6(01 04 05) DC(00 03 05) DF E0 E1 E2(00 02 04 0C 0D 0F 10 11 13 14 1D) E4 E5 E7(00 01 02) E8 E9(00 24) F0(00 0C) F1 F2 FD)mccs_ver(2.1)mswhql(1))"/>
+
+	<controls>
+		<control id="PbP" type="list" address="0xe9">
+			<value id="Off"		value="0x00"/>
+			<value id="PbP"		value="0x24"/>
+		</control>
+		<control id="inputsource" type="list" address="0x60">
+			<value id="hdmi1"	value="0x11"/>
+			<value id="hdmi2"	value="0x12"/>
+			<value id="dp"		value="0x0f"/>
+			<value id="usb-c"	value="0x1b"/>
+		</control>
+		<control id="inputsource_sub1" type="list" address="0xe8">
+			<value id="hdmi1"	value="0x11"/>
+			<value id="hdmi2"	value="0x12"/>
+			<value id="dp"		value="0x0f"/>
+			<value id="usb-c"	value="0x1b"/>
+		</control>
+
+		<control id="language" type="list" address="0xcc">
+			<value id="english"    value="0x02"/>
+			<value id="french"     value="0x03"/>
+			<value id="german"     value="0x04"/>
+			<value id="japanese"   value="0x06"/>
+			<value id="russian"    value="0x09"/>
+			<value id="spanish"    value="0x0a"/>
+			<value id="chinese"    value="0x0d"/>
+			<value id="portuguese" value="0x0e"/> <!-- Brazilian Portuguese in OSD -->
+		</control>
+
+		<control id="colorpreset" type="list" address="0x14">
+			<value id="5000k"  value="0x04"/>
+			<value id="5700k"  value="0x0b"/>
+			<value id="6500k"  value="0x05"/>
+			<value id="7500k"  value="0x06"/>
+			<value id="9300k"  value="0x08"/>
+			<value id="10000k" value="0x09"/>
+			<value id="user" value="0x0c"/>
+		</control>
+
+		<control id="magicbright" type="list" address="0xdc"><!-- Preset Mode in OSD -->
+			<value id="standard" value="0x00"/>
+			<value id="movie" value="0x03"/>
+			<value id="game" value="0x05"/>
+		</control>
+
+		<control id="power" type="list" address="0xe1">
+			<value id="off" value="1"/>
+			<value id="on"  value="0"/>
+		</control>
+
+		<control id="kvm-switch" address="0xe7">
+			<!--
+					 Incomplete, may be wrong.
+					 Source: https://www.dell.com/community/Monitors/UP2516D-DDM-KVM-USB-select-switch/td-p/6248254
+					 Confirms that E7 is the proper control, however none of the values listed worked for me.
+					 In the settings below, kvm1 and kvm2 are the USB1 and USB2 input ports respectively.
+			-->
+			<value id="kvm1-to-dp" value="0x00"/>
+			<value id="kvm2-to-dp" value="0x40"/>
+			<value id="kvm1-to-usb-c" value="0x80"/>
+		</control>
+	</controls>
+
+	<!-- enable the standard VESA controls too -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
Previous issue on the same topic: #108 (but no PR). Also https://github.com/ddccontrol/ddccontrol/issues/73 with similar findings about E7.

[Manufacturer page for the monitor](https://www.dell.com/en-us/work/shop/dell-ultrasharp-49-curved-monitor-u4919dw/apd/210-arnw/monitors-monitor-accessories)

This monitor presents itself under various EDID identifiers, depending on which video port is currently used, and sometimes whether PBP is enabled. It's also likely that HDMI1.4 vs HDMI2.0 makes a difference, but I don't have HDMI2.0 compliant hardware to test this.

The main definitions are in `U4919DW.xml`, and all the other valid EDID identifiers include that file.

* `DELA107`: using HDMI-1
* `DELA109`: using HDMI-2
* `DELA10A`: using HDMI-1 in PBP
* `DELA10B`: using HDMI-2 in PBP
* `DELA10D` and `DELA10E`: using DisplayPort. I could not reliably determine
  which (if any) is for PBP, getting both identifiers whether or not using PBP.
* `DELA10F`: using USB-C
* `DELA111`: using USB-C in PBP

Some definitions cribbed from other monitors, especially U2719D (DEL415A).

A new control is `E7`, which is related to the monitor's KVM interface. It has two USB inputs, which can be assigned in the OSD to any of its video ports. 
Using `E7` seems to assign the specific USB port to a video port, regardless whether it's currently selected, or visible in PBP mode. I was only able to discover a couple of settings; there may be more logic to the value of this control.

My reference for `E7` was this [thread on Dell community forums](https://www.dell.com/community/Monitors/UP2516D-DDM-KVM-USB-select-switch/td-p/6248254). However the values suggested there didn't work for me.