### PR TITLE
Add Samsung Odyssey G5 (DP)

### DIFF
--- a/db/monitor/SAM711A.xml
+++ b/db/monitor/SAM711A.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey G5" init="standard">
+	<include file="SAM7119"/>
+</monitor>


### PR DESCRIPTION
Support for this monitor was added back in #207, but it seems that it shows different `EDIDs` when connecting to HDMI or DP inputs.