### PR TITLE
Add Dell U2415

### DIFF
--- a/db/monitor/DELA0B8.xml
+++ b/db/monitor/DELA0B8.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2415 (DisplayPort1)" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(U2415)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(04 0B 05 06 08 09 0C) 16 18 1A 52 60(0F 10 11 12) AA(01 02 04) AC AE B2 B6 C6 C8 C9 D6(01 04 05) DC(00 02 03 05) DF E0 E1 E2(00 01 02 04 14 19 0C 0D 0F 10 11 13) F0(00 08) F1(01 02) F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
+	<controls>
+		<control id="inputsource" type="list" address="0x60">
+			<value id="dp1" value="15"/>
+			<value id="dp2" value="16"/>
+			<value id="hdmi1" value="17"/>
+			<value id="hdmi2" value="18"/>
+		</control>
+
+		<!-- power is inverted from VESA -->
+		<control id="power" type="list" address="0xe1">
+			<value id="on" value="0"/>
+			<value id="off" value="1"/>
+		</control>
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0e: +/100/0   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x3e: +/0/1   [???] -->
+		<!-- Control 0x52: +/242/255 C [???] -->
+		<!-- Control 0x6c: +/16/18   [???] -->
+		<!-- Control 0x6e: +/16/18   [???] -->
+		<!-- Control 0x70: +/16/18   [???] -->
+		<!-- Control 0xaa: +/2/255 C [OSD Orientation - Portrait] -->
+		<!-- Control 0xac: +/8564/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/1330/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/4361/17 C [???] -->
+		<!-- Control 0xc9: +/16641/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/11   [???] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+		<!-- Control 0xe2: +/0/25 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/3/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfc: +/1/1   [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+	</controls>
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA0B9.xml
+++ b/db/monitor/DELA0B9.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2415 (DisplayPort 2)" init="standard">
+	<controls>
+	</controls>
+	<include file="DELA0B8"/>
+</monitor>

--- a/db/monitor/DELA0BA.xml
+++ b/db/monitor/DELA0BA.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2415 (HDMI 1)" init="standard">
+	<controls>
+	</controls>
+	<include file="DELA0B8"/>
+</monitor>

--- a/db/monitor/DELA0BC.xml
+++ b/db/monitor/DELA0BC.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2415 (HDMI 2)" init="standard">
+	<controls>
+	</controls>
+	<include file="DELA0B8"/>
+</monitor>


### PR DESCRIPTION
Minimal control
- Input Selection: DP1 / DP2 / HDMI1 / HDMI2. selection appears to work through DisplayPort 1 (maybe others) even when a different input is selected and active (such as HDMI 1, etc)
- Power: Fix inverted power setting

Requested in #83 #152 #198

Input "DisplayPort 2" has the mini style port. Didn't see a specific option for indicating that, so I'm assuming the convention is to not describe connector size(?). Can change that if desired and there is a way to do it.
