### PR TITLE
Add Dell U2723QE via DP

### DIFF
--- a/db/monitor/DEL4278.xml
+++ b/db/monitor/DEL4278.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell U2723QE (DisplayPort1)" init="standard">
+	<include file="U2723QE"/>
+</monitor>


### PR DESCRIPTION
Alias the Dell U2723QE monitor over DisplayPort to the prior HDMI entries.