### PR TITLE
Add support for LG 34BK95U-W

### DIFF
--- a/db/monitor/GSM7721.xml
+++ b/db/monitor/GSM7721.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="LG 34BK95U-W" init="standard">
+	<include file="GSM770X"/>
+</monitor>


### PR DESCRIPTION
Exactly the same as:
- #231 

The only difference between my 34BK95U-W and the 34WK95U-W is warranty terms. This profile simply allows the 34BK95U-W to be recognized by ddccontrol. I've been using it for a year with no issues.