### PR TITLE
Add Dell P3223QE

### DIFF
--- a/db/monitor/DEL42A2.xml
+++ b/db/monitor/DEL42A2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell P3223QE (DP)" init="standard">
+	<include file="U3223QE"/>
+</monitor>

--- a/db/monitor/DEL42A3.xml
+++ b/db/monitor/DEL42A3.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Dell P3223QE (HDMI)" init="standard">
+	<include file="U3223QE"/>
+</monitor>


### PR DESCRIPTION
There are other IDs for this model, but these are the ones reported by mine. I don't have the hardware to plug it in via USB-C so I could only get the IDs via DisplayPort and HDMI.