### PR TITLE
Added support for Samsung SAM7477, Odyssey Neo G9

### DIFF
--- a/db/monitor/SAM7477.xml
+++ b/db/monitor/SAM7477.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM747A.xml
+++ b/db/monitor/SAM747A.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 1/6, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM747B.xml
+++ b/db/monitor/SAM747B.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 3, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM747C.xml
+++ b/db/monitor/SAM747C.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 2/4, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM747E.xml
+++ b/db/monitor/SAM747E.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 8 small, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM747F.xml
+++ b/db/monitor/SAM747F.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 8 large, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>

--- a/db/monitor/SAM75BE.xml
+++ b/db/monitor/SAM75BE.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA (PBP: Mode 5/7, Source: DP-1)" init="standard">
+	<include file="SAM7476" />
+</monitor>


### PR DESCRIPTION
Related to
https://github.com/ddccontrol/ddccontrol-db/pull/263/files and
https://github.com/ddccontrol/ddccontrol-db/issues/261

I also have a Neo G9 57" that reports as LS57CG952NNXZA, and the controls look identical to the 7476.

cc @Tatsh

Perhaps I could also contribute more controls to this shared file for this incredible monitor.