### PR TITLE
Add HP w19b

### DIFF
--- a/db/monitor/HWP26A0.xml
+++ b/db/monitor/HWP26A0.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<monitor name="HP w19b (VGA)" init="standard">
+    <caps add="(prot(monitor)type(LCD)mccs_ver(2.1)vcp(02 04 05 06 08 0E 10 12 14(05 06 08 0B) 16 18 1A 1E 20 30 3E 60(01 03) 62 CC(01 02 03 04 05 0A)))" remove="(vcp(AC AE B6 C0 C6 C8 C9 CA DF D6 9B 9D 9F))"/>
+    <controls>
+		<control id="colorpreset" address="0x14">
+			<value id="warm" value="0x05"/>
+			<value id="cool" value="0x06"/>
+			<value id="srgb" value="0x08"/>
+			<value id="user" value="0x0B"/>
+		</control>
+		<control id="language" address="0xcc">
+			<value id="chinese"	value="0x01"/>
+			<value id="english"	value="0x02"/>
+			<value id="french"		value="0x03"/>
+			<value id="german"	value="0x04"/>
+			<value id="italian"		value="0x05"/>
+			<value id="spanish"	value="0x0A"/>
+		</control>
+	</controls>
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HWP26A1.xml
+++ b/db/monitor/HWP26A1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<monitor name="HP w19b (DVI)" init="standard">
+	<include file="HWP26A0"/>
+</monitor>


### PR DESCRIPTION
I tested all setting on the OSD. Some of the controls are either read only or are duplicate(9d 9b 9f).

```txt
ddccontrol version 1.0.3
Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
This program comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of this program under the terms of the GNU General Public License.

Reading EDID and initializing DDC/CI at bus dev:/dev/i2c-3...

EDID readings:
	Plug and Play ID: HWP26A1 [HP w19b (DVI)]
	Input type: Analog

Capabilities:
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
Capabilities read fail.

Controls (valid/current/max) [Description - Value name]:
Control 0x02: +/2/2 C [New Control Value - Some values changed]
Control 0x04: +/0/65535 C [Restore Factory Defaults]
Control 0x05: +/0/65535 C [Restore Brightness and Contrast]
Control 0x06: +/0/65535 C [Restore Factory Default Geometry]
Control 0x08: +/0/65535 C [Restore Factory Default Color]
Control 0x0e: +/0/65535 C [Image Lock Coarse (Clock)]
Control 0x10: +/90/100 C [Brightness]
Control 0x12: +/50/100 C [Contrast]
Control 0x14: +/5/11 C [Color Preset - Warm]
Control 0x16: +/60/100 C [Red maximum level]
Control 0x18: +/60/100 C [Green maximum level]
Control 0x1a: +/60/100 C [Blue maximum level]
Control 0x1e: +/0/65535 C [Automatically adjust]
Control 0x20: +/0/65535 C [Horizontal Position]
Control 0x30: +/0/65535 C [Vertical Position]
Control 0x3e: +/0/65535 C [Image Lock Fine (Clock Phase)]
Control 0x60: +/3/3 C [Input Source Select (Main) - Digital]
Control 0x62: +/75/100 C [Audio Speaker Volume Adjust]
Control 0x9b: +/60/100   [???]
Control 0x9d: +/60/100   [???]
Control 0x9f: +/60/100   [???]
Control 0xac: +/55900/65280   [???]
Control 0xae: +/5980/65535   [???]
Control 0xb6: +/3/8   [???]
Control 0xc0: +/32767/65535   [???]
Control 0xc6: +/65535/65535   [???]
Control 0xc8: +/2/87   [???]
Control 0xc9: +/256/65535   [???]
Control 0xca: +/1/2   [???]
Control 0xcc: +/3/10 C [Language - Français (French)]
Control 0xd6: +/256/65535   [???]
Control 0xdf: +/512/1   [???]
```