### PR TITLE
Add Samsung SyncMaster E1920

### DIFF
--- a/db/monitor/SAM06A3.xml
+++ b/db/monitor/SAM06A3.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<monitor name="Samsung SyncMaster E1920" init="standard">
+	<caps add="(prot(monitor)type(LCD)model(PLUM)mccs_ver(2.0)vcp(02 04 05 06 08 0E 10 12 16 18 1A 1E 20 30 3E 87 CA(01 02) CC(02 03 04 05 08 09 0A 0B 0C 1A 1E) D6(01 04) DB(00 04) DC(01 02 03 06 F0 FB) DB(00 04 FE) E0 E8(00 07 09 0A FE) E9(00 01) EA(00 01 02 03 04) EC(00 01 02 03 04 05) F0(00 01 02 03) F2(00 01 02) F5(01 02) F7(00 01 02 03))mswhql(1))"
+		remove="(vcp(14(02 03 0A 0B) 54 60 62 6C 6E 70 AA B0(01 02) B6 C6 C8 C9 DF E1 E2 E4 E5 ED EE EF F3 F6 FE))"/>
+	<controls>
+	       <!-- e4 does some sort of pixel refresh -->
+		<control id="buttonaccess" address="0xe9">
+			<value id="locked" value="1"/>
+			<value id="unlocked" value="0"/>
+		</control>
+		<control id="screensize" address="0xdb">
+			<value id="auto" value="0"/>
+			<value id="wide" value="4" />
+		</control>
+		<control id="magicbright" address="0xdc">
+			<value id="custom" value="6"/>
+			<value id="standard" value="1"/>
+			<value id="game" value="2"/>
+			<value id="cinema" value="3"/>
+			<value id="dynamic" value="240" />
+		</control>
+		<control id="magicangle" address="0xec">
+			<value id="off" value="0"/>
+			<value id="leanback1" value="1"/>
+			<value id="leanback2" value="2"/>
+			<value id="standing" value="3"/>
+			<value id="side" value="4" />
+			<value id="custom" value="5" />
+		</control>
+		<control id="coloreffect" address="0xea">
+			<value id="off" value="0"/>
+			<value id="grayscale" value="1"/>
+			<value id="green" value="2"/>
+			<value id="aqua" value="3"/>
+			<value id="sepia" value="4"/>
+		</control>
+		<control id="gamma" address="0xf2">
+			<value id="mode1" value="0"/>
+			<value id="mode2" value="1"/>
+			<value id="mode3" value="2"/>
+		</control>
+		<control id="customkey" address="0xe8">
+			<value id="magicbright" value="0"/>
+			<value id="magicangle"  value="9"/>
+			<value id="magiceco"     value="10"/>
+			<value id="imagesize"    value="7"/>
+		</control>
+		<control id="ecomode" address="0xf7">
+			<value id="off" value="0"/>
+			<value id="low" value="1"/>
+			<value id="middle" value="2"/>
+			<value id="high" value="3"/>
+		</control>
+		<control id="language" address="0xcc">
+			<value id="english" value="2"/>
+			<value id="french"  value="3"/>
+			<value id="german"  value="4"/>
+			<value id="italian" value="5"/>
+			<value id="russian" value="9"/>
+			<value id="spanish" value="10"/>
+			<value id="swedish" value="11"/>
+			<value id="portuguese" value="8"/>
+			<value id="turkish"  value="12"/>
+			<value id="polish"  value="30"/>
+			<value id="hungarian" value="26"/>
+		</control>
+	</controls>
+	<include file="SAMlcd"/>
+</monitor>

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -383,6 +383,21 @@
 				<value id="level-2" name="Level 2" value="2"/>
 				<value id="level-3" name="Level 3" value="3"/>
 			</control>
+			<control id="coloreffect" type="list" name="Color Effect" address="0xea">
+				<value id="off" name="Off"/>
+				<value id="grayscale" name="Grayscale"/>
+				<value id="green" name="Green"/>
+				<value id="aqua" name="Aqua"/>
+				<value id="sepia" name="Sepia"/>
+			</control>
+			<control id="magicangle" type="list" name="Magic Angle Mode" address="0xec">
+				<value id="off" name="Off"/>
+				<value id="leanback1" name="Lean Back Mode 1"/>
+				<value id="leanback2" name="Lean Back Mode 2"/>
+				<value id="standing" name="Standing Mode"/>
+				<value id="side" name="Side Mode"/>
+				<value id="custom" name="Custom"/>
+			</control>
 		</subgroup>
 	</group>
 	<group name="Position and size">
@@ -749,9 +764,12 @@
 			<control id="customkey" type="list" name="Custom key" address="0xe8">
 				<value id="magicbright" name="MagicBright"/>
 				<value id="magiccolor" name="MagicColor"/>
+				<value id="magicangle" name="MagicAngle"/>
+				<value id="magiceco" name="MagicEco"/>
 				<value id="autosetup" name="Automatic setup"/>
 				<value id="inputsource" name="Input Source Select"/>
 				<value id="colortone" name="Color Tone"/>
+				<value id="imagesize" name="Image Size"/>
 			</control>
 
 			<!-- a switch to enable/disable the power led only (no other functionality,


### PR DESCRIPTION
I could not figure out what some of the proprietary (0xe - 0xf) are doing (if anything). 0x14 and 0xe0 are basically duplicate.

```txt
ddccontrol version 1.0.3
Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
This program comes with ABSOLUTELY NO WARRANTY.
You may redistribute copies of this program under the terms of the GNU General Public License.

Reading EDID and initializing DDC/CI at bus dev:/dev/i2c-2...

EDID readings:
	Plug and Play ID: SAM06A3 [Samsung SyncMaster E1920]
	Input type: Analog

Capabilities:
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
ioctl(): Inappropriate ioctl for device
ioctl returned -1
Capabilities read fail.

Controls (valid/current/max) [Description - Value name]:
Control 0x02: +/2/255 C [New Control Value - Some values changed]
Control 0x04: +/0/1 C [Restore Factory Defaults]
Control 0x05: +/0/1 C [Restore Brightness and Contrast]
Control 0x06: +/0/1 C [Restore Factory Default Geometry]
Control 0x08: +/0/1 C [Restore Factory Default Color]
Control 0x0e: +/80/160 C [Image Lock Coarse (Clock)]
Control 0x10: +/100/100 C [Brightness]
Control 0x12: +/75/100 C [Contrast]
Control 0x14: +/2/11   [???]
Control 0x16: +/50/100 C [Red maximum level]
Control 0x18: +/50/100 C [Green maximum level]
Control 0x1a: +/50/100 C [Blue maximum level]
Control 0x1e: +/0/2 C [Automatically adjust]
Control 0x20: +/66/100 C [Horizontal Position]
Control 0x30: +/12/30 C [Vertical Position]
Control 0x3e: +/2/31 C [Image Lock Fine (Clock Phase)]
Control 0x54: +/0/2   [???]
Control 0x60: +/1/3   [???]
Control 0x62: +/50/100   [???]
Control 0x6c: +/128/255   [???]
Control 0x6e: +/128/255   [???]
Control 0x70: +/128/255   [???]
Control 0x87: +/15/25 C [Sharpness]
Control 0xaa: +/0/3   [???]
Control 0xb6: +/3/9   [???]
Control 0xc6: +/1/1   [???]
Control 0xc8: +/5/16   [???]
Control 0xc9: +/1/0   [???]
Control 0xca: +/2/2 C [On Screen Display - Enable]
Control 0xcc: +/2/30 C [Language - English]
Control 0xd6: +/1/4 C [DPMS Control - On]
Control 0xdb: +/4/4 C [Screen Size - Wide]
Control 0xdc: +/6/5 C [Magic Bright Mode - Custom]
Control 0xdf: +/512/514   [???]
Control 0xe0: +/3/515 C [Color Preset - Normal]
Control 0xe1: +/1/1 C [Power control - On]
Control 0xe2: +/0/1   [???]
Control 0xe4: +/0/2   [???]
Control 0xe5: +/0/1   [???]
Control 0xe8: +/0/7 C [Custom key - MagicBright]
Control 0xe9: +/0/1 C [Button Access - Unlocked]
Control 0xea: +/0/4 C [Color Effect - Off]
Control 0xec: +/0/6 C [Magic Angle Mode - Off]
Control 0xed: +/158/255   [???]
Control 0xee: +/154/255   [???]
Control 0xef: +/158/255   [???]
Control 0xf0: +/0/3 C [MagicColor - Off]
Control 0xf2: +/0/2 C [Gamma - Mode1]
Control 0xf3: +/1/2   [???]
Control 0xf5: +/0/2 C [On Screen Display (Samsung) - Enable]
Control 0xf6: +/1/2   [???]
Control 0xf7: +/0/4 C [ECO Mode - Off]
Control 0xfe: +/1/2   [???]
```