### PR TITLE
ci: make date releases PR-based

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,168 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_date:
+        description: Release version in YYYYMMDD format. Defaults to today's UTC date.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve release version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_RELEASE_DATE: ${{ inputs.release_date }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF_NAME" != "master" ]; then
+            echo "::error::Prepare release must be run from master"
+            exit 1
+          fi
+
+          release_date="${INPUT_RELEASE_DATE:-$(date -u +%Y%m%d)}"
+
+          if ! [[ "$release_date" =~ ^[0-9]{8}$ ]]; then
+            echo "::error::release_date must use YYYYMMDD format"
+            exit 1
+          fi
+
+          parsed_date="$(date -u -d "${release_date:0:4}-${release_date:4:2}-${release_date:6:2}" +%Y%m%d 2>/dev/null || true)"
+          if [ "$parsed_date" != "$release_date" ]; then
+            echo "::error::release_date is not a valid calendar date"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$release_date" >/dev/null; then
+            echo "::error::Tag $release_date already exists"
+            exit 1
+          fi
+
+          if gh release view "$release_date" >/dev/null 2>&1; then
+            echo "::error::Release $release_date already exists"
+            exit 1
+          fi
+
+          release_branch="release/$release_date"
+
+          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
+            echo "::error::Branch $release_branch already exists"
+            exit 1
+          fi
+
+          existing_pr_count="$(gh pr list --head "$release_branch" --state open --json number --jq 'length')"
+          if [ "$existing_pr_count" != "0" ]; then
+            echo "::error::An open release PR already exists for $release_branch"
+            exit 1
+          fi
+
+          latest_tag="$(git tag --merged HEAD --sort=-creatordate | grep -E '^[0-9]{8}$' | head -n 1 || true)"
+
+          {
+            echo "release_date=$release_date"
+            echo "release_branch=$release_branch"
+            echo "latest_tag=$latest_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update release files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_DATE: ${{ steps.version.outputs.release_date }}
+          LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+          perl -0pi -e 's/AC_INIT\(\[DDC\/CI control tool database\], \[[0-9]{8}\]/AC_INIT([DDC\/CI control tool database], [$ENV{RELEASE_DATE}]/' configure.ac
+
+          configured_date="$(perl -ne 'print "$1\n" if /AC_INIT\(\[DDC\/CI control tool database\], \[([0-9]{8})\]/' configure.ac)"
+          if [ "$configured_date" != "$RELEASE_DATE" ]; then
+            echo "::error::Failed to update configure.ac to $RELEASE_DATE"
+            exit 1
+          fi
+
+          notes_args=(
+            -f "tag_name=$RELEASE_DATE"
+            -f "target_commitish=$(git rev-parse HEAD)"
+          )
+          if [ -n "$LATEST_TAG" ]; then
+            notes_args+=(-f "previous_tag_name=$LATEST_TAG")
+          fi
+
+          release_notes="$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" "${notes_args[@]}" --jq '.body')"
+          changelog_tmp="$(mktemp)"
+          {
+            echo "# Changelog"
+            echo
+            echo "## $RELEASE_DATE"
+            echo
+            printf '%s\n' "$release_notes"
+            echo
+            if [ -f CHANGELOG.md ]; then
+              awk 'NR == 1 && $0 == "# Changelog" {next} {print}' CHANGELOG.md | sed '/./,$!d'
+            fi
+          } > "$changelog_tmp"
+          mv "$changelog_tmp" CHANGELOG.md
+
+      - name: Create release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_DATE: ${{ steps.version.outputs.release_date }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.release_branch }}
+          LATEST_TAG: ${{ steps.version.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch -c "$RELEASE_BRANCH"
+          git add configure.ac CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "::error::No release file changes were generated"
+            exit 1
+          fi
+
+          git commit -m "chore: release $RELEASE_DATE"
+          git push origin "$RELEASE_BRANCH"
+
+          pr_body="$RUNNER_TEMP/release-pr-body.md"
+          {
+            echo "## Summary"
+            echo
+            echo "- prepare ddccontrol-db release \`$RELEASE_DATE\`"
+            echo "- update \`configure.ac\` to the date-based package version"
+            echo "- add generated release notes to \`CHANGELOG.md\` for review"
+            echo
+            echo "## Release"
+            echo
+            if [ -n "$LATEST_TAG" ]; then
+              echo "Previous release: \`$LATEST_TAG\`"
+            else
+              echo "Previous release: none detected"
+            fi
+            echo
+            echo "Merge this PR to publish the \`$RELEASE_DATE\` release."
+          } > "$pr_body"
+
+          gh pr create \
+            --base master \
+            --head "$RELEASE_BRANCH" \
+            --title "chore: release $RELEASE_DATE" \
+            --body-file "$pr_body"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,27 +1,31 @@
-name: Release
+name: Publish Release
 
 on:
+  pull_request:
+    types: [closed]
+    branches: [master]
   workflow_dispatch:
     inputs:
       release_date:
-        description: Release version in YYYYMMDD format. Defaults to today's UTC date.
-        required: false
+        description: Release version in YYYYMMDD format.
+        required: true
         type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: publish-release-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || inputs.release_date }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  publish-release:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -29,15 +33,20 @@ jobs:
         id: version
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           INPUT_RELEASE_DATE: ${{ inputs.release_date }}
         run: |
           set -euo pipefail
-          if [ "$GITHUB_REF_NAME" != "master" ]; then
-            echo "::error::Releases must be run from master"
-            exit 1
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            release_date="${PR_HEAD_REF#release/}"
+          else
+            if [ "$GITHUB_REF_NAME" != "master" ]; then
+              echo "::error::Manual publishing must be run from master"
+              exit 1
+            fi
+            release_date="$INPUT_RELEASE_DATE"
           fi
-
-          release_date="${INPUT_RELEASE_DATE:-$(date -u +%Y%m%d)}"
 
           if ! [[ "$release_date" =~ ^[0-9]{8}$ ]]; then
             echo "::error::release_date must use YYYYMMDD format"
@@ -47,6 +56,12 @@ jobs:
           parsed_date="$(date -u -d "${release_date:0:4}-${release_date:4:2}-${release_date:6:2}" +%Y%m%d 2>/dev/null || true)"
           if [ "$parsed_date" != "$release_date" ]; then
             echo "::error::release_date is not a valid calendar date"
+            exit 1
+          fi
+
+          configured_date="$(perl -ne 'print "$1\n" if /AC_INIT\(\[DDC\/CI control tool database\], \[([0-9]{8})\]/' configure.ac)"
+          if [ "$configured_date" != "$release_date" ]; then
+            echo "::error::configure.ac version $configured_date does not match release $release_date"
             exit 1
           fi
 
@@ -61,26 +76,6 @@ jobs:
           fi
 
           echo "release_date=$release_date" >> "$GITHUB_OUTPUT"
-
-      - name: Update package version
-        env:
-          RELEASE_DATE: ${{ steps.version.outputs.release_date }}
-        run: |
-          set -euo pipefail
-          perl -0pi -e 's/AC_INIT\(\[DDC\/CI control tool database\], \[[0-9]{8}\]/AC_INIT([DDC\/CI control tool database], [$ENV{RELEASE_DATE}]/' configure.ac
-
-      - name: Commit release version
-        env:
-          RELEASE_DATE: ${{ steps.version.outputs.release_date }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if ! git diff --quiet -- configure.ac; then
-            git add configure.ac
-            git commit -m "chore: release $RELEASE_DATE"
-          fi
 
       - name: Install build dependencies
         run: |
@@ -110,10 +105,24 @@ jobs:
           cp ddccontrol-db-*.tar.bz2 "$RUNNER_TEMP/release-artifacts/"
           cp ddccontrol-db-*.tar.xz "$RUNNER_TEMP/release-artifacts/"
 
-      - name: Push release commit
+      - name: Extract reviewed release notes
+        env:
+          RELEASE_DATE: ${{ steps.version.outputs.release_date }}
         run: |
           set -euo pipefail
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          awk -v release_date="$RELEASE_DATE" '
+            $0 == "## " release_date { found = 1; next }
+            found && /^## [0-9]{8}$/ { exit }
+            found { print }
+          ' CHANGELOG.md | sed '/./,$!d' > "$notes_file"
+
+          if [ ! -s "$notes_file" ]; then
+            echo "::error::No reviewed release notes found for $RELEASE_DATE in CHANGELOG.md"
+            exit 1
+          fi
+
+          echo "notes_file=$notes_file" >> "$GITHUB_ENV"
 
       - name: Create GitHub release
         env:
@@ -124,7 +133,7 @@ jobs:
           gh release create "$RELEASE_DATE" \
             --title "$RELEASE_DATE" \
             --target "$(git rev-parse HEAD)" \
-            --generate-notes \
+            --notes-file "$notes_file" \
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.gz \
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.bz2 \
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.xz


### PR DESCRIPTION
## Summary
- replace the direct manual release workflow with a PR-based prepare/publish release flow
- add `Prepare Release`, which opens `release/YYYYMMDD` PRs containing the `configure.ac` version bump and reviewed `CHANGELOG.md` release notes
- add `Publish Release`, which only publishes after a merged `release/YYYYMMDD` PR, or via explicit manual fallback
- keep release tags, GitHub release names, and tarball package versions as plain `YYYYMMDD`

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- tested `configure.ac` version extraction and replacement shell snippets
- tested `CHANGELOG.md` release-note section extraction shell snippet
- `./autogen.sh && ./configure && make -j"$(nproc)" && make dist-gzip && make dist-bzip2 && make dist-xz`

## Notes
This removes the workflow that committed directly to `master` during release. The release bump and generated release notes are now reviewable in a normal PR before publishing.