### PR TITLE
fix(ci): avoid release branch ref conflict

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
 
-          release_branch="release/$release_date"
+          release_branch="release-$release_date"
 
           if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
             echo "::error::Branch $release_branch already exists"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   publish-release:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            release_date="${PR_HEAD_REF#release/}"
+            release_date="${PR_HEAD_REF#release-}"
           else
             if [ "$GITHUB_REF_NAME" != "master" ]; then
               echo "::error::Manual publishing must be run from master"


### PR DESCRIPTION
## Summary

- use `release-YYYYMMDD` for generated release branches
- update the publish workflow to recognize the new branch format
- preserve date extraction for automatic publishing after merge

## Root cause

The repository already has a branch named `release`. Git therefore rejects attempts to create branches below that ref, such as `release/20260714`, with a `directory file conflict`.

## Impact

The Prepare Release workflow can push its generated branch and open the release pull request. The Publish Release workflow continues to identify merged release pull requests and derive the release date from the branch name.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `git diff --check`
- isolated Git ref test reproducing the old conflict and confirming `release-20260714` succeeds
