### PR TITLE
fix: accept Gentoo econf sysroot option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
             --localstatedir=/var \
             --sharedstatedir=/var/lib \
             --mandir=/usr/share/man \
-            --infodir=/usr/share/info
+            --infodir=/usr/share/info \
+            --with-sysroot=/
           make -j"$(nproc)"
           make check
 
@@ -131,6 +132,7 @@ jobs:
               --host="$(uname -m)-gentoo-linux-gnu" \
               --prefix=/usr \
               --datadir=/usr/share \
+              --with-sysroot=/ \
               --disable-nls
             make
             stage="$(mktemp -d)"

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_ARG_ENABLE([nls])
 AC_ARG_ENABLE([dependency-tracking])
 AC_ARG_ENABLE([silent-rules])
 AC_ARG_ENABLE([maintainer-mode])
+AC_ARG_WITH([sysroot])
 
 AC_CONFIG_COMMANDS_PRE([
   eval "set x $ac_configure_args"

--- a/configure.impl
+++ b/configure.impl
@@ -62,12 +62,12 @@ while [ "$#" -gt 0 ]; do
 		--runstatedir=*|--libdir=*|--includedir=*|--oldincludedir=*|\
 		--infodir=*|--mandir=*|--docdir=*|--htmldir=*|\
 		--dvidir=*|--pdfdir=*|--psdir=*|--program-prefix=*|--program-suffix=*|\
-		--program-transform-name=*|--cache-file=*) ;;
+		--program-transform-name=*|--cache-file=*|--with-sysroot=*) ;;
 		--build|--host|--target|--exec-prefix|--bindir|--sbindir|--libexecdir|\
 		--sysconfdir|--sharedstatedir|--localstatedir|--runstatedir|--libdir|\
 		--includedir|--oldincludedir|--infodir|--mandir|--docdir|\
 		--htmldir|--dvidir|--pdfdir|--psdir|--program-prefix|--program-suffix|\
-		--program-transform-name|--cache-file)
+		--program-transform-name|--cache-file|--with-sysroot)
 			[ "$#" -ge 2 ] || break
 			shift
 			;;


### PR DESCRIPTION
## Summary

- accept `--with-sysroot=PATH` and `--with-sysroot PATH` in the maintained configure implementation
- declare the sysroot option in the temporary Autoconf compatibility shim
- cover the option in both direct-configure and regenerated-configure CI flows

## Why

Gentoo EAPI 8 automatically passes `--with-sysroot` through `econf`. The handwritten configure implementation treated unknown `--with-*` options as errors, so an actual Gentoo ebuild configuration would stop before `make`. The option is irrelevant to this data-only package and is accepted without changing installation paths.

## Validation

- direct configure accepts both supported argument forms and still rejects unrelated unknown `--with-*` options
- Ubuntu 24.04 passes an EAPI 8-style econf argument set with NLS enabled, followed by make, check, and staged install
- Ubuntu 24.04 regenerates configure with autoreconf, passes the same Gentoo-style options with NLS disabled, and completes make, check, and staged install without warnings
- staged NLS build contains 347 monitor profiles and six gettext catalogs