### PR TITLE
feat: add Dell U2725QE monitor profile

### DIFF
--- a/db/monitor/DEL436A.xml
+++ b/db/monitor/DEL436A.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/369 -->
+<monitor name="Dell U2725QE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Other named controls remain disabled until their values are hardware-verified. -->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+
+		<!-- Known reset controls remain disabled because they can be destructive. -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+
+		<!-- Control 0x60: +/6425/14 C [Input Source Select (Main)] -->
+		<!-- Unverified candidate mappings borrowed from similar Dell profiles: -->
+		<!-- DEL4206: usb-c=0x19, dp=0x0f, hdmi1=0x11, hdmi2=0x12 -->
+		<!-- DEL437F: usb-c=0x1b, dp=0x0f, hdmi=0x11 -->
+		<!-- Input source control remains disabled pending hardware verification. -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/18/255 C [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x66: +/65/1 C [???] -->
+		<!-- Control 0x67: +/255/1 C [???] -->
+		<!-- Control 0x68: +/255/1 C [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/10556/4 C [???] -->
+		<!-- Control 0xae: +/12120/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/3/65535   [???] -->
+		<!-- Control 0xc6: +/1/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16642/65535 C [???] -->
+		<!-- Control 0xca: +/0/255 C [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe5: +/0/2 C [???] -->
+		<!-- Control 0xe6: +/1/1   [???] -->
+		<!-- Control 0xe7: +/5120/65535 C [???] -->
+		<!-- Control 0xe8: +/25/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/63488/63488 C [???] -->
+		<!-- Control 0xee: +/65420/65535 C [???] -->
+		<!-- Control 0xef: +/1/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/24842/24842 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xf5: +/0/1 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+	</controls>
+
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a monitor profile for Dell U2725QE with PNP ID `DEL436A`
- expose only the scan-confirmed brightness, contrast, and RGB gain controls
- include the VESA profile while filtering unconfirmed and potentially destructive controls
- preserve every unknown control from the scan as a comment for future investigation

## Safety

This profile is intentionally conservative. Reset controls, DPMS, OSD orientation, input switching, and all controls reported as `???` remain disabled.

Candidate input-source mappings borrowed from similar Dell profiles are commented out and clearly marked as unverified. Hardware verification from the issue author is requested before enabling those mappings or any additional controls.

## Verification

- `make check`
- `xmllint --noout db/monitor/DEL436A.xml`
- live `ddccontrol -b db -p` load recognized `DEL436A` as Dell U2725QE and exposed only brightness, contrast, and RGB gain controls

Fixes #369

Full disclosure: This pull request was created by the codex agent
