### PR TITLE
feat: add pending monitor profiles

### DIFF
--- a/db/monitor/ACI23C4.xml
+++ b/db/monitor/ACI23C4.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/95 -->
+<monitor name="ASUS VC239H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps remove="(vcp(00 02 04 05 06 08 0E 10 12 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- No controls were explicitly named by the issue scan. -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACI24A3.xml
+++ b/db/monitor/ACI24A3.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/220 -->
+<monitor name="Asus PB248" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/81/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/15 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/50/2 C [???] -->
+		<!-- Control 0x0c: +/70/2 C [???] -->
+		<!-- Control 0x0e: +/80/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/128/100   [???] -->
+		<!-- Control 0x30: +/228/100   [???] -->
+		<!-- Control 0x3e: +/251/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x62: +/54/100   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/2   [???] -->
+		<!-- Control 0x8f: +/50/100   [???] -->
+		<!-- Control 0x91: +/50/100   [???] -->
+		<!-- Control 0x93: +/50/100   [???] -->
+		<!-- Control 0xac: +/8664/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/14823/65535 C [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/34313/36 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/35 C [???] -->
+		<!-- Control 0xdc: +/0/6   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xfd: +/98/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACI27A8.xml
+++ b/db/monitor/ACI27A8.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/151 -->
+<monitor name="Asus MG278G" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/70/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/96/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/96/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/45/63 C [???] -->
+		<!-- Control 0x0e: +/45/63   [???] -->
+		<!-- Control 0x14: +/6/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/0/1 C [???] -->
+		<!-- Control 0xac: +/26492/3 C [???] -->
+		<!-- Control 0xae: +/14400/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/0/65535 C [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/34313/39 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/35 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACI28A7.xml
+++ b/db/monitor/ACI28A7.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/213 -->
+<monitor name="ASUS MG28U" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/31/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/77/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/20 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/2 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/2100/65535   [???] -->
+		<!-- Control 0x0c: +/11/11   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x86: +/2/12 C [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x8a: +/50/100 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xa8: +/1/3   [???] -->
+		<!-- Control 0xac: +/64/1 C [???] -->
+		<!-- Control 0xae: +/2990/65535 C [???] -->
+		<!-- Control 0xb0: +/1/2   [???] -->
+		<!-- Control 0xb5: +/0/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/131/255 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/0/0   [???] -->
+		<!-- Control 0xcc: +/2/49 C [???] -->
+		<!-- Control 0xdc: +/14/36 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/2/3 C [???] -->
+		<!-- Control 0xe2: +/60/100 C [???] -->
+		<!-- Control 0xe3: +/25/100 C [???] -->
+		<!-- Control 0xe4: +/0/1 C [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/5 C [???] -->
+		<!-- Control 0xe7: +/0/255 C [???] -->
+		<!-- Control 0xe8: +/0/1 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/1/1 C [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xfe: +/65535/16897   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACR046F.xml
+++ b/db/monitor/ACR046F.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/306 -->
+<monitor name="R240HY" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/48/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/76/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/85/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/84/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/63/63 C [???] -->
+		<!-- Control 0x14: +/8/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x52: +/0/65535 C [???] -->
+		<!-- Control 0x59: +/50/100   [???] -->
+		<!-- Control 0x5a: +/50/100   [???] -->
+		<!-- Control 0x5b: +/50/100   [???] -->
+		<!-- Control 0x5c: +/50/100   [???] -->
+		<!-- Control 0x5d: +/50/100   [???] -->
+		<!-- Control 0x5e: +/50/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/2/4   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x9b: +/50/100   [???] -->
+		<!-- Control 0x9c: +/50/100   [???] -->
+		<!-- Control 0x9d: +/50/100   [???] -->
+		<!-- Control 0x9e: +/50/100   [???] -->
+		<!-- Control 0x9f: +/50/100   [???] -->
+		<!-- Control 0xa0: +/50/100   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/2752/65535 C [???] -->
+		<!-- Control 0xc6: +/120/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACR0520.xml
+++ b/db/monitor/ACR0520.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/146 -->
+<monitor name="Acer H277HK" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/35/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/90/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/70/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/65506/63 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/65535 C [???] -->
+		<!-- Control 0x59: +/50/100 C [???] -->
+		<!-- Control 0x5a: +/50/100 C [???] -->
+		<!-- Control 0x5b: +/50/100 C [???] -->
+		<!-- Control 0x5c: +/50/100 C [???] -->
+		<!-- Control 0x5d: +/50/100 C [???] -->
+		<!-- Control 0x5e: +/50/100 C [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/3/4 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x9b: +/50/100 C [???] -->
+		<!-- Control 0x9c: +/50/100 C [???] -->
+		<!-- Control 0x9d: +/50/100 C [???] -->
+		<!-- Control 0x9e: +/50/100 C [???] -->
+		<!-- Control 0x9f: +/50/100 C [???] -->
+		<!-- Control 0xa0: +/50/100 C [???] -->
+		<!-- Control 0xac: +/2428/2 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/1932/65535   [???] -->
+		<!-- Control 0xc6: +/120/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe6: +/1/0   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACR0833.xml
+++ b/db/monitor/ACR0833.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/241 -->
+<monitor name="Acer Nitro XV272U KV" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/255/6 C [Power control] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 [???] -->
+		<!-- Control 0x05: +/0/1 [???] -->
+		<!-- Control 0x06: +/0/1 [???] -->
+		<!-- Control 0x08: +/0/1 [???] -->
+		<!-- Control 0x0b: +/100/0 [???] -->
+		<!-- Control 0x0c: +/35/63 [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1 [???] -->
+		<!-- Control 0x52: +/0/1 [???] -->
+		<!-- Control 0x59: +/50/100 C [???] -->
+		<!-- Control 0x5a: +/50/100 C [???] -->
+		<!-- Control 0x5b: +/50/100 C [???] -->
+		<!-- Control 0x5c: +/50/100 C [???] -->
+		<!-- Control 0x5d: +/50/100 C [???] -->
+		<!-- Control 0x5e: +/50/100 C [???] -->
+		<!-- Control 0x72: +/120/160 [???] -->
+		<!-- Control 0x87: +/2/4 [???] -->
+		<!-- Control 0x8d: +/2/1 C [???] -->
+		<!-- Control 0x9b: +/50/100 C [???] -->
+		<!-- Control 0x9c: +/50/100 C [???] -->
+		<!-- Control 0x9d: +/50/100 C [???] -->
+		<!-- Control 0x9e: +/50/100 C [???] -->
+		<!-- Control 0x9f: +/50/100 C [???] -->
+		<!-- Control 0xa0: +/50/100 C [???] -->
+		<!-- Control 0xac: +/3717/3 [???] -->
+		<!-- Control 0xae: +/17050/65535 [???] -->
+		<!-- Control 0xb2: +/1/1 [???] -->
+		<!-- Control 0xb6: +/3/5 [???] -->
+		<!-- Control 0xc6: +/90/255 [???] -->
+		<!-- Control 0xc8: +/9/0 [???] -->
+		<!-- Control 0xc9: +/1/65535 [???] -->
+		<!-- Control 0xca: +/1/2 [???] -->
+		<!-- Control 0xcc: +/2/13 [???] -->
+		<!-- Control 0xdf: +/514/65535 [???] -->
+		<!-- Control 0xe0: +/255/6 C [???] -->
+		<!-- Control 0xe2: +/0/27 C [???] -->
+		<!-- Control 0xe3: +/452/4095 C [???] -->
+		<!-- Control 0xe4: +/1/3 C [???] -->
+		<!-- Control 0xe5: +/5/10 C [???] -->
+		<!-- Control 0xe6: +/0/0 [???] -->
+		<!-- Control 0xe7: +/255/3 C [???] -->
+		<!-- Control 0xe8: +/255/3 C [???] -->
+		<!-- Control 0xe9: +/255/6 [???] -->
+		<!-- Control 0xea: +/255/6 [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ACR09BE.xml
+++ b/db/monitor/ACR09BE.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/223 -->
+<monitor name="Acer SB1 Series SB241Y Abi" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/70/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x60: +/17/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/255/10 C [Power control] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2   [???] -->
+		<!-- Control 0x05: +/0/1   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x08: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/1   [???] -->
+		<!-- Control 0x59: +/50/100 C [???] -->
+		<!-- Control 0x5a: +/50/100 C [???] -->
+		<!-- Control 0x5b: +/50/100 C [???] -->
+		<!-- Control 0x5c: +/50/100 C [???] -->
+		<!-- Control 0x5d: +/50/100 C [???] -->
+		<!-- Control 0x5e: +/50/100 C [???] -->
+		<!-- Control 0x72: +/120/160   [???] -->
+		<!-- Control 0x87: +/2/4   [???] -->
+		<!-- Control 0x9b: +/50/100 C [???] -->
+		<!-- Control 0x9c: +/50/100 C [???] -->
+		<!-- Control 0x9d: +/50/100 C [???] -->
+		<!-- Control 0x9e: +/50/100 C [???] -->
+		<!-- Control 0x9f: +/50/100 C [???] -->
+		<!-- Control 0xa0: +/50/100 C [???] -->
+		<!-- Control 0xac: +/3908/1   [???] -->
+		<!-- Control 0xae: +/7480/65535   [???] -->
+		<!-- Control 0xb2: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5   [???] -->
+		<!-- Control 0xc6: +/90/255   [???] -->
+		<!-- Control 0xc8: +/9/0   [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/13   [???] -->
+		<!-- Control 0xdf: +/514/65535   [???] -->
+		<!-- Control 0xe0: +/255/10 C [???] -->
+		<!-- Control 0xe2: +/0/27 C [???] -->
+		<!-- Control 0xe3: +/19/4095 C [???] -->
+		<!-- Control 0xe4: +/2/3 C [???] -->
+		<!-- Control 0xe5: +/5/10 C [???] -->
+		<!-- Control 0xe6: +/1/0   [???] -->
+		<!-- Control 0xe7: +/255/3 C [???] -->
+		<!-- Control 0xe8: +/255/3 C [???] -->
+		<!-- Control 0xe9: +/255/6   [???] -->
+		<!-- Control 0xea: +/255/6   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AOC2223.xml
+++ b/db/monitor/AOC2223.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/88 -->
+<monitor name="AOC E2223Pwd" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps remove="(vcp(00 02 04 05 06 08 0E 10 12 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- No controls were explicitly named by the issue scan. -->
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x05: +/0/1 C [???] -->
+		<!-- Control 0x08: +/0/1 C [???] -->
+		<!-- Control 0x10: +/0/100 C [???] -->
+		<!-- Control 0x12: +/40/100 C [???] -->
+		<!-- Control 0x14: +/6/13 C [???] -->
+		<!-- Control 0x16: +/50/100 C [???] -->
+		<!-- Control 0x18: +/50/100 C [???] -->
+		<!-- Control 0x1a: +/49/100 C [???] -->
+		<!-- Control 0x60: +/806/4 C [???] -->
+		<!-- Control 0x6e: +/50/100 C [???] -->
+		<!-- Control 0x70: +/50/100 C [???] -->
+		<!-- Control 0xae: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/255/255   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AOC2360.xml
+++ b/db/monitor/AOC2360.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/12 -->
+<monitor name="AOC I2360PHU" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/53/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/3 C [Input Source Select] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1d: +/50/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/100/100   [???] -->
+		<!-- Control 0x3e: +/100/100   [???] -->
+		<!-- Control 0x43: +/100/100   [???] -->
+		<!-- Control 0x52: +/0/255   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/50/4   [???] -->
+		<!-- Control 0x93: +/50/4   [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/30 C [???] -->
+		<!-- Control 0xcf: +/2/30   [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+		<!-- Control 0xf8: +/512/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AOC2702.xml
+++ b/db/monitor/AOC2702.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/138 -->
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/305 -->
+<monitor name="AOC Q27G2U" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/28/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x52: +/0/100 C [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x86: +/2/19 C [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/773/3 C [???] -->
+		<!-- Control 0xae: +/12010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/64/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/2/30 C [???] -->
+		<!-- Control 0xdc: +/0/16 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xed: +/0/1 C [???] -->
+		<!-- Control 0xf8: +/0/1   [???] -->
+		<!-- Control 0x0c: +/45/63 C [???] -->
+		<!-- Control 0x14: +/6/11 C [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0xac: +/1093/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xed: +/1/1 C [???] -->
+		<!-- Control 0xf8: +/1/1   [???] -->
+		<!-- Control 0xac: +/2181/3 C [???] -->
+		<!-- Control 0xae: +/15500/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AOC2710.xml
+++ b/db/monitor/AOC2710.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/106 -->
+<monitor name="AOC AG271QX" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/20/100 C [Brightness] -->
+		<!-- Control 0x12: +/40/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/45/63 C [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x14: +/6/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/0/100 C [???] -->
+		<!-- Control 0x62: +/20/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x86: +/2/19 C [???] -->
+		<!-- Control 0x87: +/0/4   [???] -->
+		<!-- Control 0xac: +/1989/3 C [???] -->
+		<!-- Control 0xae: +/14390/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/64/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/2/30 C [???] -->
+		<!-- Control 0xdc: +/0/16 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe6: +/257/0   [???] -->
+		<!-- Control 0xed: +/0/1 C [???] -->
+		<!-- Control 0xf8: +/0/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AUS1641.xml
+++ b/db/monitor/AUS1641.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/119 -->
+<monitor name="Asus ZenScreen" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/11/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x60: +/17/18   [???] -->
+		<!-- Control 0x6c: +/17/18   [???] -->
+		<!-- Control 0x6e: +/17/18   [???] -->
+		<!-- Control 0x70: +/17/18   [???] -->
+		<!-- Control 0x86: +/2/11 C [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x8a: +/50/100 C [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/629/65535   [???] -->
+		<!-- Control 0xc6: +/131/65535 C [???] -->
+		<!-- Control 0xc8: +/131/65535 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/13/49 C [???] -->
+		<!-- Control 0xdc: +/0/65535 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/514/65535 C [???] -->
+		<!-- Control 0xe3: +/0/100 C [???] -->
+		<!-- Control 0xe4: +/0/1 C [???] -->
+		<!-- Control 0xe6: +/0/4 C [???] -->
+		<!-- Control 0xe7: +/0/1 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/1/1 C [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xfd: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AUS17E0.xml
+++ b/db/monitor/AUS17E0.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/324 -->
+<monitor name="ASUS XG17A" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/8/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x72: +/120/150 C [???] -->
+		<!-- Control 0x86: +/2/12 C [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x8a: +/50/100 C [???] -->
+		<!-- Control 0xac: +/2/4028 C [???] -->
+		<!-- Control 0xae: +/12010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/132/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/9/49 C [???] -->
+		<!-- Control 0xdc: +/14/32 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe2: +/1/5 C [???] -->
+		<!-- Control 0xe4: +/0/1 C [???] -->
+		<!-- Control 0xe6: +/1/0 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/1/1 C [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xec: +/0/6 C [???] -->
+		<!-- Control 0xee: +/0/90 C [???] -->
+		<!-- Control 0xef: +/0/3 C [???] -->
+		<!-- Control 0xf0: +/0/4 C [???] -->
+		<!-- Control 0xf1: +/1/65535   [???] -->
+		<!-- Control 0xf6: +/0/2 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/AUS2464.xml
+++ b/db/monitor/AUS2464.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/259 -->
+<monitor name="ASUS ProArt PA247CV" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x03: +/0/5   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x87: +/0/100   [???] -->
+		<!-- Control 0xac: +/19064/1 C [???] -->
+		<!-- Control 0xae: +/7490/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/1271/65535 C [???] -->
+		<!-- Control 0xc6: +/133/65535 C [???] -->
+		<!-- Control 0xc8: +/29961/39 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/49 C [???] -->
+		<!-- Control 0xdc: +/0/35 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xfd: +/98/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ771B.xml
+++ b/db/monitor/BNQ771B.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/38 -->
+<monitor name="BenQ W2407" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/255 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/0/63 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/46/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/46/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/46/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/147/2 C [???] -->
+		<!-- Control 0x0b: +/2/2 C [???] -->
+		<!-- Control 0x0c: +/2/2 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1f: +/0/255 C [???] -->
+		<!-- Control 0x52: +/0/2 C [???] -->
+		<!-- Control 0x60: +/1/3   [???] -->
+		<!-- Control 0xac: +/8664/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/9429/65535 C [???] -->
+		<!-- Control 0xc8: +/18697/37 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/4/16 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ7809.xml
+++ b/db/monitor/BNQ7809.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/37 -->
+<monitor name="BenQ G2400" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/255 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/0/63 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/47/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/47/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/47/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x0b: +/2/2 C [???] -->
+		<!-- Control 0x0c: +/2/2 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1f: +/0/255 C [???] -->
+		<!-- Control 0x52: +/0/2 C [???] -->
+		<!-- Control 0xac: +/8664/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/11486/65535 C [???] -->
+		<!-- Control 0xc8: +/18697/37 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/4/16 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ780A.xml
+++ b/db/monitor/BNQ780A.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/39 -->
+<monitor name="BenQ G2400" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x3e: +/51/63 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/5/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x0b: +/2/2 C [???] -->
+		<!-- Control 0x0c: +/2/2 C [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/255   [???] -->
+		<!-- Control 0x1f: +/0/255   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/203/100   [???] -->
+		<!-- Control 0x52: +/0/2 C [???] -->
+		<!-- Control 0xac: +/8664/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/4159/65535 C [???] -->
+		<!-- Control 0xc8: +/18697/37 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/16 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ780D.xml
+++ b/db/monitor/BNQ780D.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/270 -->
+<monitor name="BenQ G2200WT" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/255 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/60/63 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/242/2 C [New Control Value] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select (Main) - Analog] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/2/2 C [???] -->
+		<!-- Control 0x0c: +/2/2 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1f: +/0/255 C [???] -->
+		<!-- Control 0x52: +/0/2 C [???] -->
+		<!-- Control 0xac: +/64900/0 C [???] -->
+		<!-- Control 0xae: +/5990/65535 C [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/8988/65535 C [???] -->
+		<!-- Control 0xc8: +/17673/37 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/16 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ78A7.xml
+++ b/db/monitor/BNQ78A7.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/51 -->
+<monitor name="BenQ GL2450H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/70/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/4 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/3000/3000 C [???] -->
+		<!-- Control 0x0c: +/70/65535 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x52: +/0/65535 C [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/3 C [???] -->
+		<!-- Control 0xac: +/2464/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/784/65535 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/5/88 C [???] -->
+		<!-- Control 0xc9: +/778/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/6   [???] -->
+		<!-- Control 0xcc: +/2/32 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xfe: +/0/0   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ78E4.xml
+++ b/db/monitor/BNQ78E4.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/225 -->
+<monitor name="BenQ GW2470" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/14/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/18/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/3000 C [???] -->
+		<!-- Control 0x0c: +/70/65535 C [???] -->
+		<!-- Control 0x0e: +/0/255   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x20: +/0/255   [???] -->
+		<!-- Control 0x30: +/0/255   [???] -->
+		<!-- Control 0x3e: +/0/255   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/128/128   [???] -->
+		<!-- Control 0x6e: +/128/128   [???] -->
+		<!-- Control 0x70: +/128/128   [???] -->
+		<!-- Control 0x72: +/120/255 C [???] -->
+		<!-- Control 0x86: +/2/5 C [???] -->
+		<!-- Control 0x87: +/6/10 C [???] -->
+		<!-- Control 0x8a: +/50/100 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x90: +/50/100 C [???] -->
+		<!-- Control 0xac: +/1964/65281 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb5: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/9279/65535 C [???] -->
+		<!-- Control 0xc6: +/60/255 C [???] -->
+		<!-- Control 0xc8: +/5/136 C [???] -->
+		<!-- Control 0xc9: +/256/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/32 C [???] -->
+		<!-- Control 0xda: +/0/255 C [???] -->
+		<!-- Control 0xdc: +/275/1 C [???] -->
+		<!-- Control 0xdf: +/514/255 C [???] -->
+		<!-- Control 0xea: +/0/5 C [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+		<!-- Control 0xee: +/0/1 C [???] -->
+		<!-- Control 0xef: +/1/1 C [???] -->
+		<!-- Control 0xf0: +/1/2 C [???] -->
+		<!-- Control 0xf4: +/0/1 C [???] -->
+		<!-- Control 0xf7: +/0/1 C [???] -->
+		<!-- Control 0xf8: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ7950.xml
+++ b/db/monitor/BNQ7950.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/244 -->
+<monitor name="BenQ EW3270U" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/35/63 C [Brightness] -->
+		<!-- Control 0x12: +/35/63 C [Contrast] -->
+		<!-- Control 0x16: +/35/63 C [Red maximum level] -->
+		<!-- Control 0x18: +/35/63 C [Green maximum level] -->
+		<!-- Control 0x1a: +/35/63 C [Blue maximum level] -->
+		<!-- Control 0x62: +/80/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/11826/10290   [???] -->
+		<!-- Control 0x01: +/11826/10290   [???] -->
+		<!-- Control 0x03: +/1/2   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0d: +/35/63   [???] -->
+		<!-- Control 0x0e: +/35/63   [???] -->
+		<!-- Control 0x0f: +/35/63   [???] -->
+		<!-- Control 0x11: +/35/63   [???] -->
+		<!-- Control 0x13: +/35/63   [???] -->
+		<!-- Control 0x14: +/35/63 C [???] -->
+		<!-- Control 0x15: +/35/63   [???] -->
+		<!-- Control 0x17: +/35/63   [???] -->
+		<!-- Control 0x19: +/35/63   [???] -->
+		<!-- Control 0x1b: +/35/63   [???] -->
+		<!-- Control 0x1c: +/35/63   [???] -->
+		<!-- Control 0x1d: +/35/63   [???] -->
+		<!-- Control 0x1e: +/35/63   [???] -->
+		<!-- Control 0x1f: +/35/63   [???] -->
+		<!-- Control 0x20: +/35/63   [???] -->
+		<!-- Control 0x21: +/35/63   [???] -->
+		<!-- Control 0x22: +/35/63   [???] -->
+		<!-- Control 0x23: +/35/63   [???] -->
+		<!-- Control 0x24: +/35/63   [???] -->
+		<!-- Control 0x25: +/35/63   [???] -->
+		<!-- Control 0x26: +/35/63   [???] -->
+		<!-- Control 0x27: +/35/63   [???] -->
+		<!-- Control 0x28: +/35/63   [???] -->
+		<!-- Control 0x29: +/35/63   [???] -->
+		<!-- Control 0x2a: +/35/63   [???] -->
+		<!-- Control 0x2b: +/35/63   [???] -->
+		<!-- Control 0x2c: +/35/63   [???] -->
+		<!-- Control 0x2d: +/35/63   [???] -->
+		<!-- Control 0x2e: +/35/63   [???] -->
+		<!-- Control 0x2f: +/35/63   [???] -->
+		<!-- Control 0x30: +/35/63   [???] -->
+		<!-- Control 0x31: +/35/63   [???] -->
+		<!-- Control 0x32: +/35/63   [???] -->
+		<!-- Control 0x33: +/35/63   [???] -->
+		<!-- Control 0x34: +/35/63   [???] -->
+		<!-- Control 0x35: +/35/63   [???] -->
+		<!-- Control 0x36: +/35/63   [???] -->
+		<!-- Control 0x37: +/35/63   [???] -->
+		<!-- Control 0x38: +/35/63   [???] -->
+		<!-- Control 0x39: +/35/63   [???] -->
+		<!-- Control 0x3a: +/35/63   [???] -->
+		<!-- Control 0x3b: +/35/63   [???] -->
+		<!-- Control 0x3c: +/35/63   [???] -->
+		<!-- Control 0x3d: +/35/63   [???] -->
+		<!-- Control 0x3e: +/35/63   [???] -->
+		<!-- Control 0x3f: +/35/63   [???] -->
+		<!-- Control 0x40: +/35/63   [???] -->
+		<!-- Control 0x41: +/35/63   [???] -->
+		<!-- Control 0x42: +/35/63   [???] -->
+		<!-- Control 0x43: +/35/63   [???] -->
+		<!-- Control 0x44: +/35/63   [???] -->
+		<!-- Control 0x45: +/35/63   [???] -->
+		<!-- Control 0x46: +/35/63   [???] -->
+		<!-- Control 0x47: +/35/63   [???] -->
+		<!-- Control 0x48: +/35/63   [???] -->
+		<!-- Control 0x49: +/35/63   [???] -->
+		<!-- Control 0x4a: +/35/63   [???] -->
+		<!-- Control 0x4b: +/35/63   [???] -->
+		<!-- Control 0x4c: +/35/63   [???] -->
+		<!-- Control 0x4d: +/35/63   [???] -->
+		<!-- Control 0x4e: +/35/63   [???] -->
+		<!-- Control 0x4f: +/35/63   [???] -->
+		<!-- Control 0x50: +/35/63   [???] -->
+		<!-- Control 0x51: +/35/63   [???] -->
+		<!-- Control 0x52: +/1/255 C [???] -->
+		<!-- Control 0x53: +/1/255   [???] -->
+		<!-- Control 0x54: +/1/255   [???] -->
+		<!-- Control 0x55: +/1/255   [???] -->
+		<!-- Control 0x56: +/1/255   [???] -->
+		<!-- Control 0x57: +/1/255   [???] -->
+		<!-- Control 0x58: +/1/255   [???] -->
+		<!-- Control 0x59: +/1/255   [???] -->
+		<!-- Control 0x5a: +/1/255   [???] -->
+		<!-- Control 0x5b: +/1/255   [???] -->
+		<!-- Control 0x5c: +/1/255   [???] -->
+		<!-- Control 0x5d: +/1/255   [???] -->
+		<!-- Control 0x5e: +/1/255   [???] -->
+		<!-- Control 0x5f: +/1/255   [???] -->
+		<!-- Control 0x61: +/15/18   [???] -->
+		<!-- Control 0x63: +/80/100   [???] -->
+		<!-- Control 0x64: +/80/100   [???] -->
+		<!-- Control 0x65: +/80/100   [???] -->
+		<!-- Control 0x66: +/80/100   [???] -->
+		<!-- Control 0x67: +/80/100   [???] -->
+		<!-- Control 0x68: +/80/100   [???] -->
+		<!-- Control 0x69: +/80/100   [???] -->
+		<!-- Control 0x6a: +/80/100   [???] -->
+		<!-- Control 0x6b: +/80/100   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6d: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x6f: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x71: +/50/100   [???] -->
+		<!-- Control 0x72: +/120/160 C [???] -->
+		<!-- Control 0x73: +/120/160   [???] -->
+		<!-- Control 0x74: +/120/160   [???] -->
+		<!-- Control 0x75: +/120/160   [???] -->
+		<!-- Control 0x76: +/120/160   [???] -->
+		<!-- Control 0x77: +/120/160   [???] -->
+		<!-- Control 0x78: +/120/160   [???] -->
+		<!-- Control 0x79: +/120/160   [???] -->
+		<!-- Control 0x7a: +/120/160   [???] -->
+		<!-- Control 0x7b: +/120/160   [???] -->
+		<!-- Control 0x7c: +/120/160   [???] -->
+		<!-- Control 0x7d: +/120/160   [???] -->
+		<!-- Control 0x7e: +/120/160   [???] -->
+		<!-- Control 0x7f: +/120/160   [???] -->
+		<!-- Control 0x80: +/120/160   [???] -->
+		<!-- Control 0x81: +/120/160   [???] -->
+		<!-- Control 0x82: +/120/160   [???] -->
+		<!-- Control 0x83: +/120/160   [???] -->
+		<!-- Control 0x84: +/120/160   [???] -->
+		<!-- Control 0x85: +/120/160   [???] -->
+		<!-- Control 0x86: +/2/5 C [???] -->
+		<!-- Control 0x87: +/10/10 C [???] -->
+		<!-- Control 0x88: +/10/10   [???] -->
+		<!-- Control 0x89: +/10/10   [???] -->
+		<!-- Control 0x8a: +/60/100   [???] -->
+		<!-- Control 0x8b: +/60/100   [???] -->
+		<!-- Control 0x8c: +/60/100   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x8e: +/2/2   [???] -->
+		<!-- Control 0x8f: +/2/2   [???] -->
+		<!-- Control 0x90: +/45/100   [???] -->
+		<!-- Control 0x91: +/45/100   [???] -->
+		<!-- Control 0x92: +/45/100   [???] -->
+		<!-- Control 0x93: +/45/100   [???] -->
+		<!-- Control 0x94: +/45/100   [???] -->
+		<!-- Control 0x95: +/45/100   [???] -->
+		<!-- Control 0x96: +/45/100   [???] -->
+		<!-- Control 0x97: +/45/100   [???] -->
+		<!-- Control 0x98: +/45/100   [???] -->
+		<!-- Control 0x99: +/45/100   [???] -->
+		<!-- Control 0x9a: +/45/100   [???] -->
+		<!-- Control 0x9b: +/45/100   [???] -->
+		<!-- Control 0x9c: +/45/100   [???] -->
+		<!-- Control 0x9d: +/45/100   [???] -->
+		<!-- Control 0x9e: +/45/100   [???] -->
+		<!-- Control 0x9f: +/45/100   [???] -->
+		<!-- Control 0xa0: +/45/100   [???] -->
+		<!-- Control 0xa1: +/45/100   [???] -->
+		<!-- Control 0xa2: +/45/100   [???] -->
+		<!-- Control 0xa3: +/45/100   [???] -->
+		<!-- Control 0xa4: +/45/100   [???] -->
+		<!-- Control 0xa5: +/45/100   [???] -->
+		<!-- Control 0xa6: +/45/100   [???] -->
+		<!-- Control 0xa7: +/45/100   [???] -->
+		<!-- Control 0xa8: +/45/100   [???] -->
+		<!-- Control 0xa9: +/45/100   [???] -->
+		<!-- Control 0xaa: +/45/100   [???] -->
+		<!-- Control 0xab: +/45/100   [???] -->
+		<!-- Control 0xac: +/4228/0 C [???] -->
+		<!-- Control 0xad: +/4228/0   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb3: +/1/2   [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb5: +/0/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/1509/65535 C [???] -->
+		<!-- Control 0xc1: +/1509/65535   [???] -->
+		<!-- Control 0xc2: +/1509/65535   [???] -->
+		<!-- Control 0xc3: +/1509/65535   [???] -->
+		<!-- Control 0xc4: +/1509/65535   [???] -->
+		<!-- Control 0xc5: +/1509/65535   [???] -->
+		<!-- Control 0xc6: +/60/65535 C [???] -->
+		<!-- Control 0xc7: +/60/65535   [???] -->
+		<!-- Control 0xc8: +/38409/39 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/16 C [???] -->
+		<!-- Control 0xcd: +/2/16   [???] -->
+		<!-- Control 0xce: +/2/16   [???] -->
+		<!-- Control 0xcf: +/2/16   [???] -->
+		<!-- Control 0xd0: +/2/16   [???] -->
+		<!-- Control 0xd1: +/2/16   [???] -->
+		<!-- Control 0xd2: +/2/16   [???] -->
+		<!-- Control 0xd3: +/2/16   [???] -->
+		<!-- Control 0xd4: +/2/16   [???] -->
+		<!-- Control 0xd5: +/2/16   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5 C [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdb: +/0/2   [???] -->
+		<!-- Control 0xdc: +/275/1043 C [???] -->
+		<!-- Control 0xdd: +/275/1043   [???] -->
+		<!-- Control 0xde: +/275/1043   [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/514/65535   [???] -->
+		<!-- Control 0xe1: +/514/65535   [???] -->
+		<!-- Control 0xe2: +/514/65535 C [???] -->
+		<!-- Control 0xe3: +/514/65535 C [???] -->
+		<!-- Control 0xe4: +/514/65535   [???] -->
+		<!-- Control 0xe5: +/514/65535   [???] -->
+		<!-- Control 0xe6: +/514/65535   [???] -->
+		<!-- Control 0xe7: +/514/65535 C [???] -->
+		<!-- Control 0xe8: +/514/65535 C [???] -->
+		<!-- Control 0xe9: +/514/65535 C [???] -->
+		<!-- Control 0xea: +/514/65535 C [???] -->
+		<!-- Control 0xeb: +/514/65535   [???] -->
+		<!-- Control 0xec: +/514/65535   [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+		<!-- Control 0xee: +/1/2   [???] -->
+		<!-- Control 0xef: +/0/1 C [???] -->
+		<!-- Control 0xf0: +/1/2 C [???] -->
+		<!-- Control 0xf1: +/1/2 C [???] -->
+		<!-- Control 0xf2: +/1/2 C [???] -->
+		<!-- Control 0xf3: +/1/2   [???] -->
+		<!-- Control 0xf4: +/1/2 C [???] -->
+		<!-- Control 0xf5: +/1/2 C [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xf7: +/1/1 C [???] -->
+		<!-- Control 0xf8: +/20/30 C [???] -->
+		<!-- Control 0xf9: +/20/30 C [???] -->
+		<!-- Control 0xfa: +/20/30   [???] -->
+		<!-- Control 0xfb: +/20/30   [???] -->
+		<!-- Control 0xfc: +/20/30   [???] -->
+		<!-- Control 0xfd: +/0/0   [???] -->
+		<!-- Control 0xff: +/0/0   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ7F0C.xml
+++ b/db/monitor/BNQ7F0C.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/319 -->
+<monitor name="BenQ RL2240HE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/15 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/114/10537   [???] -->
+		<!-- Control 0x01: +/114/10537   [???] -->
+		<!-- Control 0x03: +/2/2   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0d: +/35/63   [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x0f: +/0/100   [???] -->
+		<!-- Control 0x11: +/100/100   [???] -->
+		<!-- Control 0x13: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x15: +/5/11   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x21: +/0/100   [???] -->
+		<!-- Control 0x22: +/0/100   [???] -->
+		<!-- Control 0x23: +/0/100   [???] -->
+		<!-- Control 0x24: +/0/100   [???] -->
+		<!-- Control 0x25: +/0/100   [???] -->
+		<!-- Control 0x26: +/0/100   [???] -->
+		<!-- Control 0x27: +/0/100   [???] -->
+		<!-- Control 0x28: +/0/100   [???] -->
+		<!-- Control 0x29: +/0/100   [???] -->
+		<!-- Control 0x2a: +/0/100   [???] -->
+		<!-- Control 0x2b: +/0/100   [???] -->
+		<!-- Control 0x2c: +/0/100   [???] -->
+		<!-- Control 0x2d: +/0/100   [???] -->
+		<!-- Control 0x2e: +/0/100   [???] -->
+		<!-- Control 0x2f: +/0/100   [???] -->
+		<!-- Control 0x30: +/15/100   [???] -->
+		<!-- Control 0x31: +/15/100   [???] -->
+		<!-- Control 0x32: +/15/100   [???] -->
+		<!-- Control 0x33: +/15/100   [???] -->
+		<!-- Control 0x34: +/15/100   [???] -->
+		<!-- Control 0x35: +/15/100   [???] -->
+		<!-- Control 0x36: +/15/100   [???] -->
+		<!-- Control 0x37: +/15/100   [???] -->
+		<!-- Control 0x38: +/15/100   [???] -->
+		<!-- Control 0x39: +/15/100   [???] -->
+		<!-- Control 0x3a: +/15/100   [???] -->
+		<!-- Control 0x3b: +/15/100   [???] -->
+		<!-- Control 0x3c: +/15/100   [???] -->
+		<!-- Control 0x3d: +/15/100   [???] -->
+		<!-- Control 0x3e: +/30/63   [???] -->
+		<!-- Control 0x3f: +/30/63   [???] -->
+		<!-- Control 0x40: +/30/63   [???] -->
+		<!-- Control 0x41: +/30/63   [???] -->
+		<!-- Control 0x42: +/30/63   [???] -->
+		<!-- Control 0x43: +/30/63   [???] -->
+		<!-- Control 0x44: +/30/63   [???] -->
+		<!-- Control 0x45: +/30/63   [???] -->
+		<!-- Control 0x46: +/30/63   [???] -->
+		<!-- Control 0x47: +/30/63   [???] -->
+		<!-- Control 0x48: +/30/63   [???] -->
+		<!-- Control 0x49: +/30/63   [???] -->
+		<!-- Control 0x4a: +/30/63   [???] -->
+		<!-- Control 0x4b: +/30/63   [???] -->
+		<!-- Control 0x4c: +/30/63   [???] -->
+		<!-- Control 0x4d: +/30/63   [???] -->
+		<!-- Control 0x4e: +/30/63   [???] -->
+		<!-- Control 0x4f: +/30/63   [???] -->
+		<!-- Control 0x50: +/30/63   [???] -->
+		<!-- Control 0x51: +/30/63   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x53: +/96/255   [???] -->
+		<!-- Control 0x54: +/96/255   [???] -->
+		<!-- Control 0x55: +/96/255   [???] -->
+		<!-- Control 0x56: +/96/255   [???] -->
+		<!-- Control 0x57: +/96/255   [???] -->
+		<!-- Control 0x58: +/96/255   [???] -->
+		<!-- Control 0x59: +/96/255   [???] -->
+		<!-- Control 0x5a: +/96/255   [???] -->
+		<!-- Control 0x5b: +/96/255   [???] -->
+		<!-- Control 0x5c: +/96/255   [???] -->
+		<!-- Control 0x5d: +/96/255   [???] -->
+		<!-- Control 0x5e: +/96/255   [???] -->
+		<!-- Control 0x5f: +/96/255   [???] -->
+		<!-- Control 0x61: +/4/15   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6d: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x6f: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x71: +/50/100   [???] -->
+		<!-- Control 0x72: +/50/100   [???] -->
+		<!-- Control 0x73: +/50/100   [???] -->
+		<!-- Control 0x74: +/50/100   [???] -->
+		<!-- Control 0x75: +/50/100   [???] -->
+		<!-- Control 0x76: +/50/100   [???] -->
+		<!-- Control 0x77: +/50/100   [???] -->
+		<!-- Control 0x78: +/50/100   [???] -->
+		<!-- Control 0x79: +/50/100   [???] -->
+		<!-- Control 0x7a: +/50/100   [???] -->
+		<!-- Control 0x7b: +/50/100   [???] -->
+		<!-- Control 0x7c: +/50/100   [???] -->
+		<!-- Control 0x7d: +/50/100   [???] -->
+		<!-- Control 0x7e: +/50/100   [???] -->
+		<!-- Control 0x7f: +/50/100   [???] -->
+		<!-- Control 0x80: +/50/100   [???] -->
+		<!-- Control 0x81: +/50/100   [???] -->
+		<!-- Control 0x82: +/50/100   [???] -->
+		<!-- Control 0x83: +/50/100   [???] -->
+		<!-- Control 0x84: +/50/100   [???] -->
+		<!-- Control 0x85: +/50/100   [???] -->
+		<!-- Control 0x86: +/50/100   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x88: +/50/100   [???] -->
+		<!-- Control 0x89: +/50/100   [???] -->
+		<!-- Control 0x8a: +/50/100   [???] -->
+		<!-- Control 0x8b: +/50/100   [???] -->
+		<!-- Control 0x8c: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x8e: +/2/2   [???] -->
+		<!-- Control 0x8f: +/2/2   [???] -->
+		<!-- Control 0x90: +/2/2   [???] -->
+		<!-- Control 0x91: +/2/2   [???] -->
+		<!-- Control 0x92: +/2/2   [???] -->
+		<!-- Control 0x93: +/2/2   [???] -->
+		<!-- Control 0x94: +/2/2   [???] -->
+		<!-- Control 0x95: +/2/2   [???] -->
+		<!-- Control 0x96: +/2/2   [???] -->
+		<!-- Control 0x97: +/2/2   [???] -->
+		<!-- Control 0x98: +/2/2   [???] -->
+		<!-- Control 0x99: +/2/2   [???] -->
+		<!-- Control 0x9a: +/2/2   [???] -->
+		<!-- Control 0x9b: +/2/2   [???] -->
+		<!-- Control 0x9c: +/2/2   [???] -->
+		<!-- Control 0x9d: +/2/2   [???] -->
+		<!-- Control 0x9e: +/2/2   [???] -->
+		<!-- Control 0x9f: +/2/2   [???] -->
+		<!-- Control 0xa0: +/2/2   [???] -->
+		<!-- Control 0xa1: +/2/2   [???] -->
+		<!-- Control 0xa2: +/2/2   [???] -->
+		<!-- Control 0xa3: +/2/2   [???] -->
+		<!-- Control 0xa4: +/2/2   [???] -->
+		<!-- Control 0xa5: +/2/2   [???] -->
+		<!-- Control 0xa6: +/2/2   [???] -->
+		<!-- Control 0xa7: +/2/2   [???] -->
+		<!-- Control 0xa8: +/2/2   [???] -->
+		<!-- Control 0xa9: +/2/2   [???] -->
+		<!-- Control 0xaa: +/2/2   [???] -->
+		<!-- Control 0xab: +/2/2   [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xad: +/2064/1   [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xaf: +/6010/65535   [???] -->
+		<!-- Control 0xb0: +/6010/65535   [???] -->
+		<!-- Control 0xb1: +/6010/65535   [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb3: +/1/2   [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb5: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/21886/65535 C [???] -->
+		<!-- Control 0xc1: +/21886/65535   [???] -->
+		<!-- Control 0xc2: +/21886/65535   [???] -->
+		<!-- Control 0xc3: +/21886/65535   [???] -->
+		<!-- Control 0xc4: +/21886/65535   [???] -->
+		<!-- Control 0xc5: +/21886/65535   [???] -->
+		<!-- Control 0xc6: +/120/65535 C [???] -->
+		<!-- Control 0xc7: +/120/65535   [???] -->
+		<!-- Control 0xc8: +/33545/36 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/16 C [???] -->
+		<!-- Control 0xcd: +/2/16   [???] -->
+		<!-- Control 0xce: +/2/16   [???] -->
+		<!-- Control 0xcf: +/2/16   [???] -->
+		<!-- Control 0xd0: +/2/16   [???] -->
+		<!-- Control 0xd1: +/2/16   [???] -->
+		<!-- Control 0xd2: +/2/16   [???] -->
+		<!-- Control 0xd3: +/2/16   [???] -->
+		<!-- Control 0xd4: +/2/16   [???] -->
+		<!-- Control 0xd5: +/2/16   [???] -->
+		<!-- Control 0xd7: +/1/4   [???] -->
+		<!-- Control 0xd8: +/1/4   [???] -->
+		<!-- Control 0xd9: +/1/4   [???] -->
+		<!-- Control 0xda: +/1/4   [???] -->
+		<!-- Control 0xdb: +/1/4   [???] -->
+		<!-- Control 0xdc: +/0/9   [???] -->
+		<!-- Control 0xdd: +/0/9   [???] -->
+		<!-- Control 0xde: +/0/9   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/513/65535   [???] -->
+		<!-- Control 0xe1: +/513/65535   [???] -->
+		<!-- Control 0xe2: +/513/65535   [???] -->
+		<!-- Control 0xe3: +/513/65535   [???] -->
+		<!-- Control 0xe4: +/513/65535   [???] -->
+		<!-- Control 0xe5: +/513/65535   [???] -->
+		<!-- Control 0xe6: +/513/65535   [???] -->
+		<!-- Control 0xe7: +/513/65535   [???] -->
+		<!-- Control 0xe8: +/513/65535   [???] -->
+		<!-- Control 0xe9: +/513/65535   [???] -->
+		<!-- Control 0xea: +/513/65535   [???] -->
+		<!-- Control 0xeb: +/513/65535   [???] -->
+		<!-- Control 0xec: +/513/65535   [???] -->
+		<!-- Control 0xed: +/513/65535   [???] -->
+		<!-- Control 0xee: +/513/65535   [???] -->
+		<!-- Control 0xef: +/513/65535   [???] -->
+		<!-- Control 0xf0: +/0/5   [???] -->
+		<!-- Control 0xf1: +/1/1   [???] -->
+		<!-- Control 0xf2: +/1/1   [???] -->
+		<!-- Control 0xf3: +/1/1   [???] -->
+		<!-- Control 0xf4: +/1/1   [???] -->
+		<!-- Control 0xf5: +/1/1   [???] -->
+		<!-- Control 0xf6: +/1/1   [???] -->
+		<!-- Control 0xf7: +/1/1   [???] -->
+		<!-- Control 0xf8: +/1/1   [???] -->
+		<!-- Control 0xf9: +/1/1   [???] -->
+		<!-- Control 0xfa: +/1/1   [???] -->
+		<!-- Control 0xfb: +/1/1   [???] -->
+		<!-- Control 0xfc: +/1/1   [???] -->
+		<!-- Control 0xfd: +/1/1   [???] -->
+		<!-- Control 0xfe: +/1/1   [???] -->
+		<!-- Control 0xff: +/1/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ801B.xml
+++ b/db/monitor/BNQ801B.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/32 -->
+<monitor name="BenQ BL2420PT" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/255 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xaa: +/2/100 C [OSD Orientation - Portrait] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/70/126 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/50/100 [???] -->
+		<!-- Control 0x6e: +/50/100 [???] -->
+		<!-- Control 0x70: +/50/100 [???] -->
+		<!-- Control 0x72: +/120/160 C [???] -->
+		<!-- Control 0x86: +/2/5 C [???] -->
+		<!-- Control 0x87: +/5/10 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/23264/65281 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb5: +/0/255 [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xc0: +/168/65535 C [???] -->
+		<!-- Control 0xc6: +/60/65535 C [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/7/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/4/255 C [???] -->
+		<!-- Control 0xd8: +/6/6 C [???] -->
+		<!-- Control 0xdc: +/0/19 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe2: +/1/1 C [???] -->
+		<!-- Control 0xe3: +/0/1 C [???] -->
+		<!-- Control 0xe7: +/0/255 C [???] -->
+		<!-- Control 0xe8: +/0/255 C [???] -->
+		<!-- Control 0xe9: +/0/3 C [???] -->
+		<!-- Control 0xef: +/1/1 C [???] -->
+		<!-- Control 0xf0: +/1/2 C [???] -->
+		<!-- Control 0xf1: +/0/1 C [???] -->
+		<!-- Control 0xf2: +/1300/6500 C [???] -->
+		<!-- Control 0xf5: +/1/3 C [???] -->
+		<!-- Control 0xf6: +/1/1 C [???] -->
+		<!-- Control 0xf7: +/0/1 C [???] -->
+		<!-- Control 0xf8: +/0/30 C [???] -->
+		<!-- Control 0xf9: +/1/10 C [???] -->
+		<!-- Control 0xfc: +/1/1 [???] -->
+		<!-- Control 0xfe: +/0/255 [???] -->
+		<!-- Control 0xff: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/BNQ802E.xml
+++ b/db/monitor/BNQ802E.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/100 -->
+<monitor name="BenQ PD2700U" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/16/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/18 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On]                       Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/25443/10605   [???] -->
+		<!-- Control 0x01: +/25443/10605   [???] -->
+		<!-- Control 0x03: +/16/2   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0d: +/35/63   [???] -->
+		<!-- Control 0x0e: +/35/63   [???] -->
+		<!-- Control 0x0f: +/35/63   [???] -->
+		<!-- Control 0x11: +/50/100   [???] -->
+		<!-- Control 0x13: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x15: +/5/11   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/100/100   [???] -->
+		<!-- Control 0x1f: +/100/100   [???] -->
+		<!-- Control 0x20: +/100/100   [???] -->
+		<!-- Control 0x21: +/100/100   [???] -->
+		<!-- Control 0x22: +/100/100   [???] -->
+		<!-- Control 0x23: +/100/100   [???] -->
+		<!-- Control 0x24: +/100/100   [???] -->
+		<!-- Control 0x25: +/100/100   [???] -->
+		<!-- Control 0x26: +/100/100   [???] -->
+		<!-- Control 0x27: +/100/100   [???] -->
+		<!-- Control 0x28: +/100/100   [???] -->
+		<!-- Control 0x29: +/100/100   [???] -->
+		<!-- Control 0x2a: +/100/100   [???] -->
+		<!-- Control 0x2b: +/100/100   [???] -->
+		<!-- Control 0x2c: +/100/100   [???] -->
+		<!-- Control 0x2d: +/100/100   [???] -->
+		<!-- Control 0x2e: +/100/100   [???] -->
+		<!-- Control 0x2f: +/100/100   [???] -->
+		<!-- Control 0x30: +/100/100   [???] -->
+		<!-- Control 0x31: +/100/100   [???] -->
+		<!-- Control 0x32: +/100/100   [???] -->
+		<!-- Control 0x33: +/100/100   [???] -->
+		<!-- Control 0x34: +/100/100   [???] -->
+		<!-- Control 0x35: +/100/100   [???] -->
+		<!-- Control 0x36: +/100/100   [???] -->
+		<!-- Control 0x37: +/100/100   [???] -->
+		<!-- Control 0x38: +/100/100   [???] -->
+		<!-- Control 0x39: +/100/100   [???] -->
+		<!-- Control 0x3a: +/100/100   [???] -->
+		<!-- Control 0x3b: +/100/100   [???] -->
+		<!-- Control 0x3c: +/100/100   [???] -->
+		<!-- Control 0x3d: +/100/100   [???] -->
+		<!-- Control 0x3e: +/100/100   [???] -->
+		<!-- Control 0x3f: +/100/100   [???] -->
+		<!-- Control 0x40: +/100/100   [???] -->
+		<!-- Control 0x41: +/100/100   [???] -->
+		<!-- Control 0x42: +/100/100   [???] -->
+		<!-- Control 0x43: +/100/100   [???] -->
+		<!-- Control 0x45: +/100/100   [???] -->
+		<!-- Control 0x46: +/100/100   [???] -->
+		<!-- Control 0x47: +/100/100   [???] -->
+		<!-- Control 0x48: +/100/100   [???] -->
+		<!-- Control 0x49: +/100/100   [???] -->
+		<!-- Control 0x4a: +/100/100   [???] -->
+		<!-- Control 0x4b: +/100/100   [???] -->
+		<!-- Control 0x4c: +/100/100   [???] -->
+		<!-- Control 0x4d: +/100/100   [???] -->
+		<!-- Control 0x4e: +/100/100   [???] -->
+		<!-- Control 0x4f: +/100/100   [???] -->
+		<!-- Control 0x50: +/100/100   [???] -->
+		<!-- Control 0x51: +/100/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x53: +/16/255   [???] -->
+		<!-- Control 0x54: +/16/255   [???] -->
+		<!-- Control 0x55: +/16/255   [???] -->
+		<!-- Control 0x56: +/16/255   [???] -->
+		<!-- Control 0x57: +/16/255   [???] -->
+		<!-- Control 0x58: +/16/255   [???] -->
+		<!-- Control 0x59: +/16/255   [???] -->
+		<!-- Control 0x5a: +/16/255   [???] -->
+		<!-- Control 0x5b: +/16/255   [???] -->
+		<!-- Control 0x5c: +/16/255   [???] -->
+		<!-- Control 0x5d: +/16/255   [???] -->
+		<!-- Control 0x5e: +/16/255   [???] -->
+		<!-- Control 0x5f: +/16/255   [???] -->
+		<!-- Control 0x61: +/16/18   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6d: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x6f: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x71: +/50/100   [???] -->
+		<!-- Control 0x72: +/140/160 C [???] -->
+		<!-- Control 0x73: +/140/160   [???] -->
+		<!-- Control 0x74: +/140/160   [???] -->
+		<!-- Control 0x75: +/140/160   [???] -->
+		<!-- Control 0x76: +/140/160   [???] -->
+		<!-- Control 0x77: +/140/160   [???] -->
+		<!-- Control 0x78: +/140/160   [???] -->
+		<!-- Control 0x79: +/140/160   [???] -->
+		<!-- Control 0x7a: +/140/160   [???] -->
+		<!-- Control 0x7b: +/140/160   [???] -->
+		<!-- Control 0x7c: +/140/160   [???] -->
+		<!-- Control 0x7d: +/0/2 C [???] -->
+		<!-- Control 0x7e: +/17/18 C [???] -->
+		<!-- Control 0x7f: +/17/18 C [???] -->
+		<!-- Control 0x80: +/1/770 C [???] -->
+		<!-- Control 0x81: +/1/770   [???] -->
+		<!-- Control 0x82: +/1/770   [???] -->
+		<!-- Control 0x83: +/1/770   [???] -->
+		<!-- Control 0x84: +/1/770   [???] -->
+		<!-- Control 0x85: +/1/770   [???] -->
+		<!-- Control 0x86: +/2/23 C [???] -->
+		<!-- Control 0x87: +/5/10 C [???] -->
+		<!-- Control 0x88: +/5/10   [???] -->
+		<!-- Control 0x89: +/5/10   [???] -->
+		<!-- Control 0x8a: +/50/100 C [???] -->
+		<!-- Control 0x8b: +/50/100   [???] -->
+		<!-- Control 0x8c: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x8e: +/2/2   [???] -->
+		<!-- Control 0x8f: +/2/2   [???] -->
+		<!-- Control 0x90: +/50/100 C [???] -->
+		<!-- Control 0x91: +/50/100   [???] -->
+		<!-- Control 0x92: +/50/100   [???] -->
+		<!-- Control 0x93: +/50/100   [???] -->
+		<!-- Control 0x94: +/50/100   [???] -->
+		<!-- Control 0x95: +/50/100   [???] -->
+		<!-- Control 0x96: +/50/100   [???] -->
+		<!-- Control 0x97: +/50/100   [???] -->
+		<!-- Control 0x98: +/50/100   [???] -->
+		<!-- Control 0x99: +/50/100   [???] -->
+		<!-- Control 0x9a: +/50/100   [???] -->
+		<!-- Control 0x9b: +/50/100   [???] -->
+		<!-- Control 0x9c: +/50/100   [???] -->
+		<!-- Control 0x9d: +/50/100   [???] -->
+		<!-- Control 0x9e: +/50/100   [???] -->
+		<!-- Control 0x9f: +/50/100   [???] -->
+		<!-- Control 0xa0: +/50/100   [???] -->
+		<!-- Control 0xa1: +/50/100   [???] -->
+		<!-- Control 0xa2: +/50/100   [???] -->
+		<!-- Control 0xa3: +/50/100   [???] -->
+		<!-- Control 0xa4: +/50/100   [???] -->
+		<!-- Control 0xa5: +/50/100   [???] -->
+		<!-- Control 0xa6: +/50/100   [???] -->
+		<!-- Control 0xa7: +/50/100   [???] -->
+		<!-- Control 0xa8: +/50/100   [???] -->
+		<!-- Control 0xa9: +/50/100   [???] -->
+		<!-- Control 0xab: +/1/255   [???] -->
+		<!-- Control 0xac: +/2428/2 C [???] -->
+		<!-- Control 0xad: +/2428/2   [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xaf: +/6010/65535   [???] -->
+		<!-- Control 0xb0: +/6010/65535   [???] -->
+		<!-- Control 0xb1: +/6010/65535   [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb3: +/1/2   [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb5: +/0/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/433/65535 C [???] -->
+		<!-- Control 0xc1: +/433/65535   [???] -->
+		<!-- Control 0xc2: +/433/65535   [???] -->
+		<!-- Control 0xc3: +/433/65535   [???] -->
+		<!-- Control 0xc4: +/433/65535   [???] -->
+		<!-- Control 0xc5: +/433/65535   [???] -->
+		<!-- Control 0xc7: +/60/65535   [???] -->
+		<!-- Control 0xc8: +/38665/39 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/16 C [???] -->
+		<!-- Control 0xcd: +/2/16   [???] -->
+		<!-- Control 0xce: +/2/16   [???] -->
+		<!-- Control 0xcf: +/2/16   [???] -->
+		<!-- Control 0xd0: +/2/16   [???] -->
+		<!-- Control 0xd1: +/2/16   [???] -->
+		<!-- Control 0xd2: +/2/16   [???] -->
+		<!-- Control 0xd3: +/2/16   [???] -->
+		<!-- Control 0xd4: +/2/16   [???] -->
+		<!-- Control 0xd5: +/2/16   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/4/3   [???] -->
+		<!-- Control 0xd9: +/4/3   [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdb: +/0/2   [???] -->
+		<!-- Control 0xdc: +/35/1043 C [???] -->
+		<!-- Control 0xdd: +/35/1043   [???] -->
+		<!-- Control 0xde: +/35/1043   [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/514/65535   [???] -->
+		<!-- Control 0xe1: +/514/65535   [???] -->
+		<!-- Control 0xe2: +/1/1 C [???] -->
+		<!-- Control 0xe3: +/0/1 C [???] -->
+		<!-- Control 0xe4: +/2/3   [???] -->
+		<!-- Control 0xe5: +/50/100 C [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/5 C [???] -->
+		<!-- Control 0xeb: +/0/5   [???] -->
+		<!-- Control 0xec: +/0/5   [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+		<!-- Control 0xee: +/2/2   [???] -->
+		<!-- Control 0xef: +/1/1 C [???] -->
+		<!-- Control 0xf0: +/1/2 C [???] -->
+		<!-- Control 0xf1: +/0/1 C [???] -->
+		<!-- Control 0xf2: +/1300/3 C [???] -->
+		<!-- Control 0xf3: +/1300/3   [???] -->
+		<!-- Control 0xf4: +/0/8193 C [???] -->
+		<!-- Control 0xf5: +/0/8193   [???] -->
+		<!-- Control 0xf6: +/0/1 C [???] -->
+		<!-- Control 0xf7: +/0/1 C [???] -->
+		<!-- Control 0xf8: +/0/30 C [???] -->
+		<!-- Control 0xf9: +/7/10 C [???] -->
+		<!-- Control 0xfa: +/7/10   [???] -->
+		<!-- Control 0xfb: +/7/10   [???] -->
+		<!-- Control 0xfc: +/7/10   [???] -->
+		<!-- Control 0xfd: +/4/5   [???] -->
+		<!-- Control 0xfe: +/4/5   [???] -->
+		<!-- Control 0xd5: +/2/16   [???]                                    Control 0xd5: +/2/16   [???] -->
+		<!-- Control 0xd7: +/1/5   [???]                                     Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/4/3   [???]                                     Control 0xd8: +/4/3   [???] -->
+		<!-- Control 0xd9: +/4/3   [???]                                     Control 0xd9: +/4/3   [???] -->
+		<!-- Control 0xda: +/0/2 C [???]                                     Control 0xda: +/0/2 C [???] -->
+		<!-- Control 0xdb: +/0/2   [???]                                     Control 0xdb: +/0/2   [???] -->
+		<!-- Control 0xdc: +/10/1043 C [???]                                 Control 0xdc: +/10/1043 C [???] -->
+		<!-- Control 0xdd: +/10/1043   [???]                                 Control 0xdd: +/10/1043   [???] -->
+		<!-- Control 0xde: +/10/1043   [???]                                 Control 0xde: +/10/1043   [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???]                               Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/514/65535   [???]                               Control 0xe0: +/514/65535   [???] -->
+		<!-- Control 0xe1: +/514/65535   [???]                               Control 0xe1: +/514/65535   [???] -->
+		<!-- Control 0xe2: +/1/1 C [???]                                     Control 0xe2: +/1/1 C [???] -->
+		<!-- Control 0xe3: +/0/1 C [???]                                     Control 0xe3: +/0/1 C [???] -->
+		<!-- Control 0xe4: +/2/3   [???]                                   | Control 0xe4: +/3/3   [???] -->
+		<!-- Control 0xe5: +/50/100 C [???]                                  Control 0xe5: +/50/100 C [???] -->
+		<!-- Control 0xe6: +/1/0   [???]                                     Control 0xe6: +/1/0   [???] -->
+		<!-- Control 0xe7: +/1/0   [???]                                     Control 0xe7: +/1/0   [???] -->
+		<!-- Control 0xe8: +/1/0   [???]                                     Control 0xe8: +/1/0   [???] -->
+		<!-- Control 0xe9: +/1/0   [???]                                     Control 0xe9: +/1/0   [???] -->
+		<!-- Control 0xea: +/0/5 C [???]                                     Control 0xea: +/0/5 C [???] -->
+		<!-- Control 0xeb: +/0/5   [???]                                     Control 0xeb: +/0/5   [???] -->
+		<!-- Control 0xec: +/0/5   [???]                                     Control 0xec: +/0/5   [???] -->
+		<!-- Control 0xed: +/1/1   [???]                                     Control 0xed: +/1/1   [???] -->
+		<!-- Control 0xe4: +/3/3   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4073.xml
+++ b/db/monitor/DEL4073.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/19 -->
+<monitor name="Dell UltraSharp U2312HM" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/15 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/100/0 [???] -->
+		<!-- Control 0x0e: +/143/100 [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1 [???] -->
+		<!-- Control 0x1f: +/1/1 [???] -->
+		<!-- Control 0x20: +/200/100 [???] -->
+		<!-- Control 0x30: +/85/100 [???] -->
+		<!-- Control 0x37: +/85/100 [???] -->
+		<!-- Control 0x3e: +/122/100 [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/15/15 [???] -->
+		<!-- Control 0x6e: +/15/15 [???] -->
+		<!-- Control 0x70: +/15/15 [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/981/65535 [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/34313/36 C [???] -->
+		<!-- Control 0xc9: +/0/65535 C [???] -->
+		<!-- Control 0xca: +/1/2 [???] -->
+		<!-- Control 0xcc: +/2/11 [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf2: +/1/1 [???] -->
+		<!-- Control 0xfd: +/116/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL407E.xml
+++ b/db/monitor/DEL407E.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/60 -->
+<monitor name="Dell U2412M" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/95/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/90/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/255 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/14 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/186/100   [???] -->
+		<!-- Control 0x30: +/34/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/22864/1 C [???] -->
+		<!-- Control 0xae: +/5970/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/5318/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/255   [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/7/1 C [???] -->
+		<!-- Control 0xf2: +/0/1 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL407F.xml
+++ b/db/monitor/DEL407F.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/2 -->
+<monitor name="Dell U2713HM" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/68/100 C [Brightness] -->
+		<!-- Control 0x12: +/56/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/255 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/14 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/10/100   [???] -->
+		<!-- Control 0x30: +/21/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/18/255 C [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/43900/0 C [???] -->
+		<!-- Control 0xae: +/2990/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/712/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/255   [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/15/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/7/1 C [???] -->
+		<!-- Control 0xf2: +/0/1 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4081.xml
+++ b/db/monitor/DEL4081.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/14 -->
+<monitor name="DELL U3014" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/45/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/65535 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/65535 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/65535 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/65535 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x11: +/0/65535   [???] -->
+		<!-- Control 0x13: +/0/65535   [???] -->
+		<!-- Control 0x14: +/0/65535 C [???] -->
+		<!-- Control 0x15: +/0/65535   [???] -->
+		<!-- Control 0x17: +/0/65535   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x68: +/1/2   [???] -->
+		<!-- Control 0x6c: +/0/65535   [???] -->
+		<!-- Control 0x6e: +/0/65535   [???] -->
+		<!-- Control 0x70: +/0/65535   [???] -->
+		<!-- Control 0x77: +/0/65535   [???] -->
+		<!-- Control 0x8a: +/50/65535   [???] -->
+		<!-- Control 0x8c: +/12/65535   [???] -->
+		<!-- Control 0xac: +/33164/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb0: +/0/1   [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc0: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/269/147 C [???] -->
+		<!-- Control 0xc9: +/513/65535 C [???] -->
+		<!-- Control 0xca: +/0/2   [???] -->
+		<!-- Control 0xcc: +/2/11   [???] -->
+		<!-- Control 0xdc: +/0/65535 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe2: +/0/65535 C [???] -->
+		<!-- Control 0xe3: +/0/65535 C [???] -->
+		<!-- Control 0xe4: +/0/65535 C [???] -->
+		<!-- Control 0xf0: +/0/65535 C [???] -->
+		<!-- Control 0xf1: +/3/65535 C [???] -->
+		<!-- Control 0xf2: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL40BD.xml
+++ b/db/monitor/DEL40BD.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/112 -->
+<monitor name="Dell P2715Q" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/255 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/17 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/65535 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/65535 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x52: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xac: +/2228/2 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/513/65535 C [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe2: +/20/25 C [???] -->
+		<!-- Control 0xe4: +/0/65535 C [???] -->
+		<!-- Control 0xf0: +/0/65535 C [???] -->
+		<!-- Control 0xf1: +/3/65535 C [???] -->
+		<!-- Control 0xf2: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL40EA.xml
+++ b/db/monitor/DEL40EA.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/91 -->
+<monitor name="Dell U2717D (U2717DA)" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/255 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/17 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/65535 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/65535 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/1/12 C [???] -->
+		<!-- Control 0x52: +/0/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16644/65535 C [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/11/25 C [???] -->
+		<!-- Control 0xf0: +/0/65535 C [???] -->
+		<!-- Control 0xf1: +/3/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfd: +/116/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL413C.xml
+++ b/db/monitor/DEL413C.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/79 -->
+<monitor name="Dell U2518D" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/17 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/65535 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/65535 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/0/12 C [???] -->
+		<!-- Control 0x52: +/20/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/3/8   [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/513/65535 C [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe2: +/0/25 C [???] -->
+		<!-- Control 0xf0: +/0/65535 C [???] -->
+		<!-- Control 0xf1: +/139/65535 C [???] -->
+		<!-- Control 0xf2: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4147.xml
+++ b/db/monitor/DEL4147.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/302 -->
+<monitor name="Dell UP3218K (8k)" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4883/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/4/255 C [DPMS Control - Standby] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/20/255 C [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/64292/3 C [???] -->
+		<!-- Control 0xae: +/5973/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/6163/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/11011/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe4: +/1/1 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/11 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4148.xml
+++ b/db/monitor/DEL4148.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/99 -->
+<monitor name="Dell U2419H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/25/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3855/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/4 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/24438/25459   [???] -->
+		<!-- Control 0x01: +/24438/25459   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/50/100   [???] -->
+		<!-- Control 0x11: +/25/100   [???] -->
+		<!-- Control 0x13: +/75/100   [???] -->
+		<!-- Control 0x14: +/75/100 C [???] -->
+		<!-- Control 0x15: +/75/100   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x21: +/50/100   [???] -->
+		<!-- Control 0x22: +/50/100   [???] -->
+		<!-- Control 0x23: +/50/100   [???] -->
+		<!-- Control 0x24: +/50/100   [???] -->
+		<!-- Control 0x25: +/50/100   [???] -->
+		<!-- Control 0x26: +/50/100   [???] -->
+		<!-- Control 0x27: +/50/100   [???] -->
+		<!-- Control 0x28: +/50/100   [???] -->
+		<!-- Control 0x29: +/50/100   [???] -->
+		<!-- Control 0x2a: +/50/100   [???] -->
+		<!-- Control 0x2b: +/50/100   [???] -->
+		<!-- Control 0x2c: +/50/100   [???] -->
+		<!-- Control 0x2d: +/50/100   [???] -->
+		<!-- Control 0x2e: +/50/100   [???] -->
+		<!-- Control 0x2f: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x31: +/50/100   [???] -->
+		<!-- Control 0x32: +/50/100   [???] -->
+		<!-- Control 0x33: +/50/100   [???] -->
+		<!-- Control 0x34: +/50/100   [???] -->
+		<!-- Control 0x35: +/50/100   [???] -->
+		<!-- Control 0x36: +/50/100   [???] -->
+		<!-- Control 0x37: +/50/100   [???] -->
+		<!-- Control 0x38: +/50/100   [???] -->
+		<!-- Control 0x39: +/50/100   [???] -->
+		<!-- Control 0x3a: +/50/100   [???] -->
+		<!-- Control 0x3b: +/50/100   [???] -->
+		<!-- Control 0x3c: +/50/100   [???] -->
+		<!-- Control 0x3d: +/50/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/50/100   [???] -->
+		<!-- Control 0x40: +/50/100   [???] -->
+		<!-- Control 0x41: +/50/100   [???] -->
+		<!-- Control 0x42: +/50/100   [???] -->
+		<!-- Control 0x43: +/50/100   [???] -->
+		<!-- Control 0x44: +/50/100   [???] -->
+		<!-- Control 0x45: +/50/100   [???] -->
+		<!-- Control 0x46: +/50/100   [???] -->
+		<!-- Control 0x47: +/50/100   [???] -->
+		<!-- Control 0x48: +/50/100   [???] -->
+		<!-- Control 0x49: +/50/100   [???] -->
+		<!-- Control 0x4a: +/50/100   [???] -->
+		<!-- Control 0x4b: +/50/100   [???] -->
+		<!-- Control 0x4c: +/50/100   [???] -->
+		<!-- Control 0x4d: +/50/100   [???] -->
+		<!-- Control 0x4e: +/50/100   [???] -->
+		<!-- Control 0x4f: +/50/100   [???] -->
+		<!-- Control 0x50: +/50/100   [???] -->
+		<!-- Control 0x51: +/50/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x53: +/16/255   [???] -->
+		<!-- Control 0x54: +/16/255   [???] -->
+		<!-- Control 0x55: +/16/255   [???] -->
+		<!-- Control 0x56: +/16/255   [???] -->
+		<!-- Control 0x57: +/16/255   [???] -->
+		<!-- Control 0x58: +/16/255   [???] -->
+		<!-- Control 0x59: +/16/255   [???] -->
+		<!-- Control 0x5a: +/16/255   [???] -->
+		<!-- Control 0x5b: +/16/255   [???] -->
+		<!-- Control 0x5c: +/16/255   [???] -->
+		<!-- Control 0x5d: +/16/255   [???] -->
+		<!-- Control 0x5e: +/16/255   [???] -->
+		<!-- Control 0x5f: +/16/255   [???] -->
+		<!-- Control 0x61: +/3855/4626   [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/100/100   [???] -->
+		<!-- Control 0x6d: +/100/100   [???] -->
+		<!-- Control 0x6e: +/100/100   [???] -->
+		<!-- Control 0x6f: +/100/100   [???] -->
+		<!-- Control 0x70: +/100/100   [???] -->
+		<!-- Control 0x71: +/100/100   [???] -->
+		<!-- Control 0x72: +/100/100   [???] -->
+		<!-- Control 0x73: +/100/100   [???] -->
+		<!-- Control 0x74: +/100/100   [???] -->
+		<!-- Control 0x75: +/100/100   [???] -->
+		<!-- Control 0x76: +/100/100   [???] -->
+		<!-- Control 0x77: +/100/100   [???] -->
+		<!-- Control 0x78: +/100/100   [???] -->
+		<!-- Control 0x79: +/100/100   [???] -->
+		<!-- Control 0x7a: +/100/100   [???] -->
+		<!-- Control 0x7b: +/100/100   [???] -->
+		<!-- Control 0x7c: +/100/100   [???] -->
+		<!-- Control 0x7d: +/100/100   [???] -->
+		<!-- Control 0x7e: +/100/100   [???] -->
+		<!-- Control 0x7f: +/100/100   [???] -->
+		<!-- Control 0x80: +/100/100   [???] -->
+		<!-- Control 0x81: +/100/100   [???] -->
+		<!-- Control 0x82: +/100/100   [???] -->
+		<!-- Control 0x83: +/100/100   [???] -->
+		<!-- Control 0x84: +/100/100   [???] -->
+		<!-- Control 0x85: +/100/100   [???] -->
+		<!-- Control 0x86: +/100/100   [???] -->
+		<!-- Control 0x87: +/100/100   [???] -->
+		<!-- Control 0x88: +/100/100   [???] -->
+		<!-- Control 0x89: +/100/100   [???] -->
+		<!-- Control 0x8a: +/100/100   [???] -->
+		<!-- Control 0x8b: +/100/100   [???] -->
+		<!-- Control 0x8c: +/100/100   [???] -->
+		<!-- Control 0x8d: +/100/100   [???] -->
+		<!-- Control 0x8e: +/100/100   [???] -->
+		<!-- Control 0x8f: +/100/100   [???] -->
+		<!-- Control 0x90: +/100/100   [???] -->
+		<!-- Control 0x91: +/100/100   [???] -->
+		<!-- Control 0x92: +/100/100   [???] -->
+		<!-- Control 0x93: +/100/100   [???] -->
+		<!-- Control 0x94: +/100/100   [???] -->
+		<!-- Control 0x95: +/100/100   [???] -->
+		<!-- Control 0x96: +/100/100   [???] -->
+		<!-- Control 0x97: +/100/100   [???] -->
+		<!-- Control 0x98: +/100/100   [???] -->
+		<!-- Control 0x99: +/100/100   [???] -->
+		<!-- Control 0x9a: +/100/100   [???] -->
+		<!-- Control 0x9b: +/100/100   [???] -->
+		<!-- Control 0x9c: +/100/100   [???] -->
+		<!-- Control 0x9d: +/100/100   [???] -->
+		<!-- Control 0x9e: +/100/100   [???] -->
+		<!-- Control 0x9f: +/100/100   [???] -->
+		<!-- Control 0xa0: +/100/100   [???] -->
+		<!-- Control 0xa1: +/100/100   [???] -->
+		<!-- Control 0xa2: +/100/100   [???] -->
+		<!-- Control 0xa3: +/100/100   [???] -->
+		<!-- Control 0xa4: +/100/100   [???] -->
+		<!-- Control 0xa5: +/100/100   [???] -->
+		<!-- Control 0xa6: +/100/100   [???] -->
+		<!-- Control 0xa7: +/100/100   [???] -->
+		<!-- Control 0xa8: +/100/100   [???] -->
+		<!-- Control 0xa9: +/100/100   [???] -->
+		<!-- Control 0xab: +/1/4   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xad: +/1964/1   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/6/65535   [???] -->
+		<!-- Control 0xc1: +/6/65535   [???] -->
+		<!-- Control 0xc2: +/6/65535   [???] -->
+		<!-- Control 0xc3: +/6/65535   [???] -->
+		<!-- Control 0xc4: +/6/65535   [???] -->
+		<!-- Control 0xc5: +/6/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/29961/39 C [???] -->
+		<!-- Control 0xc9: +/259/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcb: +/1/2   [???] -->
+		<!-- Control 0xcc: +/3/13 C [???] -->
+		<!-- Control 0xcd: +/3/13   [???] -->
+		<!-- Control 0xce: +/3/13   [???] -->
+		<!-- Control 0xcf: +/3/13   [???] -->
+		<!-- Control 0xd0: +/3/13   [???] -->
+		<!-- Control 0xd1: +/3/13   [???] -->
+		<!-- Control 0xd2: +/3/13   [???] -->
+		<!-- Control 0xd3: +/3/13   [???] -->
+		<!-- Control 0xd4: +/3/13   [???] -->
+		<!-- Control 0xd5: +/3/13   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/255 C [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/255   [???] -->
+		<!-- Control 0xe6: +/0/255   [???] -->
+		<!-- Control 0xe7: +/0/15   [???] -->
+		<!-- Control 0xe8: +/15/65535   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xea: +/65024/65025   [???] -->
+		<!-- Control 0xeb: +/1/1   [???] -->
+		<!-- Control 0xec: +/1/1   [???] -->
+		<!-- Control 0xed: +/1/1   [???] -->
+		<!-- Control 0xee: +/1/1   [???] -->
+		<!-- Control 0xef: +/1/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf3: +/0/255   [???] -->
+		<!-- Control 0xf4: +/0/255   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf6: +/0/255   [???] -->
+		<!-- Control 0xf7: +/0/255   [???] -->
+		<!-- Control 0xf8: +/0/255   [???] -->
+		<!-- Control 0xf9: +/0/255   [???] -->
+		<!-- Control 0xfa: +/0/255   [???] -->
+		<!-- Control 0xfb: +/0/255   [???] -->
+		<!-- Control 0xfc: +/0/255   [???] -->
+		<!-- Control 0xfd: +/116/255 C [???] -->
+		<!-- Control 0xfe: +/116/255   [???] -->
+		<!-- Control 0xff: +/116/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL41B0.xml
+++ b/db/monitor/DEL41B0.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/260 -->
+<monitor name="Dell U2720Q" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps remove="(vcp(00 02 04 05 06 08 0E 10 12 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- No controls were explicitly named by the issue scan. -->
+		<!--
+			Unverified candidate mappings borrowed from the Dell U2720Q
+			DEL41B7 profile remain disabled pending hardware verification:
+
+			brightness=0x10, contrast=0x12, red=0x16,
+			green=0x18, blue=0x1a
+
+			Input source candidates:
+			usb-c=0x1b, displayport=0x0f, hdmi=0x11
+		-->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL41F4.xml
+++ b/db/monitor/DEL41F4.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/191 -->
+<monitor name="Dell S2421HS" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/65/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/65/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/65/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/65/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4369/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/10292/25968   [???] -->
+		<!-- Control 0x01: +/10292/25968   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/50/100   [???] -->
+		<!-- Control 0x11: +/65/100   [???] -->
+		<!-- Control 0x13: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x15: +/5/12   [???] -->
+		<!-- Control 0x17: +/65/100   [???] -->
+		<!-- Control 0x19: +/65/100   [???] -->
+		<!-- Control 0x1b: +/65/100   [???] -->
+		<!-- Control 0x1c: +/65/100   [???] -->
+		<!-- Control 0x1d: +/65/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x21: +/50/100   [???] -->
+		<!-- Control 0x22: +/50/100   [???] -->
+		<!-- Control 0x23: +/50/100   [???] -->
+		<!-- Control 0x24: +/50/100   [???] -->
+		<!-- Control 0x25: +/50/100   [???] -->
+		<!-- Control 0x26: +/50/100   [???] -->
+		<!-- Control 0x27: +/50/100   [???] -->
+		<!-- Control 0x28: +/50/100   [???] -->
+		<!-- Control 0x29: +/50/100   [???] -->
+		<!-- Control 0x2a: +/50/100   [???] -->
+		<!-- Control 0x2b: +/50/100   [???] -->
+		<!-- Control 0x2c: +/50/100   [???] -->
+		<!-- Control 0x2d: +/50/100   [???] -->
+		<!-- Control 0x2e: +/50/100   [???] -->
+		<!-- Control 0x2f: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x31: +/50/100   [???] -->
+		<!-- Control 0x32: +/50/100   [???] -->
+		<!-- Control 0x33: +/50/100   [???] -->
+		<!-- Control 0x34: +/50/100   [???] -->
+		<!-- Control 0x35: +/50/100   [???] -->
+		<!-- Control 0x36: +/50/100   [???] -->
+		<!-- Control 0x37: +/50/100   [???] -->
+		<!-- Control 0x38: +/50/100   [???] -->
+		<!-- Control 0x39: +/50/100   [???] -->
+		<!-- Control 0x3a: +/50/100   [???] -->
+		<!-- Control 0x3b: +/50/100   [???] -->
+		<!-- Control 0x3c: +/50/100   [???] -->
+		<!-- Control 0x3d: +/50/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/50/100   [???] -->
+		<!-- Control 0x40: +/50/100   [???] -->
+		<!-- Control 0x41: +/50/100   [???] -->
+		<!-- Control 0x42: +/50/100   [???] -->
+		<!-- Control 0x43: +/50/100   [???] -->
+		<!-- Control 0x44: +/50/100   [???] -->
+		<!-- Control 0x45: +/50/100   [???] -->
+		<!-- Control 0x46: +/50/100   [???] -->
+		<!-- Control 0x47: +/50/100   [???] -->
+		<!-- Control 0x48: +/50/100   [???] -->
+		<!-- Control 0x49: +/50/100   [???] -->
+		<!-- Control 0x4a: +/50/100   [???] -->
+		<!-- Control 0x4b: +/50/100   [???] -->
+		<!-- Control 0x4c: +/50/100   [???] -->
+		<!-- Control 0x4d: +/50/100   [???] -->
+		<!-- Control 0x4e: +/50/100   [???] -->
+		<!-- Control 0x4f: +/50/100   [???] -->
+		<!-- Control 0x50: +/50/100   [???] -->
+		<!-- Control 0x51: +/50/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x53: +/16/255   [???] -->
+		<!-- Control 0x54: +/16/255   [???] -->
+		<!-- Control 0x55: +/16/255   [???] -->
+		<!-- Control 0x56: +/16/255   [???] -->
+		<!-- Control 0x57: +/16/255   [???] -->
+		<!-- Control 0x58: +/16/255   [???] -->
+		<!-- Control 0x59: +/16/255   [???] -->
+		<!-- Control 0x5a: +/16/255   [???] -->
+		<!-- Control 0x5b: +/16/255   [???] -->
+		<!-- Control 0x5c: +/16/255   [???] -->
+		<!-- Control 0x5d: +/16/255   [???] -->
+		<!-- Control 0x5e: +/16/255   [???] -->
+		<!-- Control 0x5f: +/16/255   [???] -->
+		<!-- Control 0x61: +/4369/4626   [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/100/100   [???] -->
+		<!-- Control 0x6d: +/100/100   [???] -->
+		<!-- Control 0x6e: +/100/100   [???] -->
+		<!-- Control 0x6f: +/100/100   [???] -->
+		<!-- Control 0x70: +/100/100   [???] -->
+		<!-- Control 0x71: +/100/100   [???] -->
+		<!-- Control 0x72: +/100/100   [???] -->
+		<!-- Control 0x73: +/100/100   [???] -->
+		<!-- Control 0x74: +/100/100   [???] -->
+		<!-- Control 0x75: +/100/100   [???] -->
+		<!-- Control 0x76: +/100/100   [???] -->
+		<!-- Control 0x77: +/100/100   [???] -->
+		<!-- Control 0x78: +/100/100   [???] -->
+		<!-- Control 0x79: +/100/100   [???] -->
+		<!-- Control 0x7a: +/100/100   [???] -->
+		<!-- Control 0x7b: +/100/100   [???] -->
+		<!-- Control 0x7c: +/100/100   [???] -->
+		<!-- Control 0x7d: +/100/100   [???] -->
+		<!-- Control 0x7e: +/100/100   [???] -->
+		<!-- Control 0x7f: +/100/100   [???] -->
+		<!-- Control 0x80: +/100/100   [???] -->
+		<!-- Control 0x81: +/100/100   [???] -->
+		<!-- Control 0x82: +/100/100   [???] -->
+		<!-- Control 0x83: +/100/100   [???] -->
+		<!-- Control 0x84: +/100/100   [???] -->
+		<!-- Control 0x85: +/100/100   [???] -->
+		<!-- Control 0x86: +/100/100   [???] -->
+		<!-- Control 0x87: +/100/100   [???] -->
+		<!-- Control 0x88: +/100/100   [???] -->
+		<!-- Control 0x89: +/100/100   [???] -->
+		<!-- Control 0x8a: +/100/100   [???] -->
+		<!-- Control 0x8b: +/100/100   [???] -->
+		<!-- Control 0x8c: +/100/100   [???] -->
+		<!-- Control 0x8d: +/100/100   [???] -->
+		<!-- Control 0x8e: +/100/100   [???] -->
+		<!-- Control 0x8f: +/100/100   [???] -->
+		<!-- Control 0x90: +/100/100   [???] -->
+		<!-- Control 0x91: +/100/100   [???] -->
+		<!-- Control 0x92: +/100/100   [???] -->
+		<!-- Control 0x93: +/100/100   [???] -->
+		<!-- Control 0x94: +/100/100   [???] -->
+		<!-- Control 0x95: +/100/100   [???] -->
+		<!-- Control 0x96: +/100/100   [???] -->
+		<!-- Control 0x97: +/100/100   [???] -->
+		<!-- Control 0x98: +/100/100   [???] -->
+		<!-- Control 0x99: +/100/100   [???] -->
+		<!-- Control 0x9a: +/100/100   [???] -->
+		<!-- Control 0x9b: +/100/100   [???] -->
+		<!-- Control 0x9c: +/100/100   [???] -->
+		<!-- Control 0x9d: +/100/100   [???] -->
+		<!-- Control 0x9e: +/100/100   [???] -->
+		<!-- Control 0x9f: +/100/100   [???] -->
+		<!-- Control 0xa0: +/100/100   [???] -->
+		<!-- Control 0xa1: +/100/100   [???] -->
+		<!-- Control 0xa2: +/100/100   [???] -->
+		<!-- Control 0xa3: +/100/100   [???] -->
+		<!-- Control 0xa4: +/100/100   [???] -->
+		<!-- Control 0xa5: +/100/100   [???] -->
+		<!-- Control 0xa6: +/100/100   [???] -->
+		<!-- Control 0xa7: +/100/100   [???] -->
+		<!-- Control 0xa8: +/100/100   [???] -->
+		<!-- Control 0xa9: +/100/100   [???] -->
+		<!-- Control 0xaa: +/1/4   [???] -->
+		<!-- Control 0xab: +/1/4   [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xad: +/2064/1   [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xaf: +/6010/65535   [???] -->
+		<!-- Control 0xb0: +/6010/65535   [???] -->
+		<!-- Control 0xb1: +/6010/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/22/65535   [???] -->
+		<!-- Control 0xc1: +/22/65535   [???] -->
+		<!-- Control 0xc2: +/22/65535   [???] -->
+		<!-- Control 0xc3: +/22/65535   [???] -->
+		<!-- Control 0xc4: +/22/65535   [???] -->
+		<!-- Control 0xc5: +/22/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/9481/37 C [???] -->
+		<!-- Control 0xc9: +/259/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/2   [???] -->
+		<!-- Control 0xcc: +/9/13 C [???] -->
+		<!-- Control 0xcd: +/9/13   [???] -->
+		<!-- Control 0xce: +/9/13   [???] -->
+		<!-- Control 0xcf: +/9/13   [???] -->
+		<!-- Control 0xd0: +/9/13   [???] -->
+		<!-- Control 0xd1: +/9/13   [???] -->
+		<!-- Control 0xd2: +/9/13   [???] -->
+		<!-- Control 0xd3: +/9/13   [???] -->
+		<!-- Control 0xd4: +/9/13   [???] -->
+		<!-- Control 0xd5: +/9/13   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/255   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/255   [???] -->
+		<!-- Control 0xe6: +/1/0   [???] -->
+		<!-- Control 0xe7: +/0/15   [???] -->
+		<!-- Control 0xe8: +/17/65535   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xea: +/0/65535   [???] -->
+		<!-- Control 0xeb: +/1/1   [???] -->
+		<!-- Control 0xec: +/1/1   [???] -->
+		<!-- Control 0xed: +/1/1   [???] -->
+		<!-- Control 0xee: +/1/1   [???] -->
+		<!-- Control 0xef: +/1/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf3: +/0/255   [???] -->
+		<!-- Control 0xf4: +/0/255   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf6: +/0/255   [???] -->
+		<!-- Control 0xf7: +/0/255   [???] -->
+		<!-- Control 0xf8: +/0/255   [???] -->
+		<!-- Control 0xf9: +/0/255   [???] -->
+		<!-- Control 0xfa: +/0/255   [???] -->
+		<!-- Control 0xfb: +/0/255   [???] -->
+		<!-- Control 0xfc: +/0/255   [???] -->
+		<!-- Control 0xfd: +/116/255 C [???] -->
+		<!-- Control 0xfe: +/116/255   [???] -->
+		<!-- Control 0xff: +/116/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4279.xml
+++ b/db/monitor/DEL4279.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/321 -->
+<monitor name="Dell U2723QE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/60/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6939/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/2228/2 C [???] -->
+		<!-- Control 0xae: +/5999/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/4/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16641/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe7: +/65530/65450 C [???] -->
+		<!-- Control 0xe8: +/27/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/65024/65024 C [???] -->
+		<!-- Control 0xef: +/0/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/16651/16651 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DEL4308.xml
+++ b/db/monitor/DEL4308.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/264 -->
+<monitor name="Dell U4025QW" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/21/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/80/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6425/6425 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/65535   [???] -->
+		<!-- Control 0x01: +/0/65535   [???] -->
+		<!-- Control 0x03: +/0/65535   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/65535   [???] -->
+		<!-- Control 0x09: +/0/65535   [???] -->
+		<!-- Control 0x0a: +/0/65535   [???] -->
+		<!-- Control 0x0b: +/0/65535   [???] -->
+		<!-- Control 0x0c: +/0/65535   [???] -->
+		<!-- Control 0x0d: +/0/65535   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/0/65535   [???] -->
+		<!-- Control 0x11: +/0/65535   [???] -->
+		<!-- Control 0x13: +/0/65535   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x15: +/0/65535   [???] -->
+		<!-- Control 0x17: +/0/65535   [???] -->
+		<!-- Control 0x19: +/0/65535   [???] -->
+		<!-- Control 0x1b: +/0/65535   [???] -->
+		<!-- Control 0x1c: +/0/65535   [???] -->
+		<!-- Control 0x1d: +/0/65535   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x21: +/0/65535   [???] -->
+		<!-- Control 0x22: +/0/65535   [???] -->
+		<!-- Control 0x23: +/0/65535   [???] -->
+		<!-- Control 0x24: +/0/65535   [???] -->
+		<!-- Control 0x25: +/0/65535   [???] -->
+		<!-- Control 0x26: +/0/65535   [???] -->
+		<!-- Control 0x27: +/0/65535   [???] -->
+		<!-- Control 0x28: +/0/65535   [???] -->
+		<!-- Control 0x29: +/0/65535   [???] -->
+		<!-- Control 0x2a: +/0/65535   [???] -->
+		<!-- Control 0x2b: +/0/65535   [???] -->
+		<!-- Control 0x2c: +/0/65535   [???] -->
+		<!-- Control 0x2d: +/0/65535   [???] -->
+		<!-- Control 0x2e: +/0/65535   [???] -->
+		<!-- Control 0x2f: +/0/65535   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x31: +/0/65535   [???] -->
+		<!-- Control 0x32: +/0/65535   [???] -->
+		<!-- Control 0x33: +/0/65535   [???] -->
+		<!-- Control 0x34: +/0/65535   [???] -->
+		<!-- Control 0x35: +/0/65535   [???] -->
+		<!-- Control 0x36: +/0/65535   [???] -->
+		<!-- Control 0x37: +/0/65535   [???] -->
+		<!-- Control 0x38: +/0/65535   [???] -->
+		<!-- Control 0x39: +/0/65535   [???] -->
+		<!-- Control 0x3a: +/0/65535   [???] -->
+		<!-- Control 0x3b: +/0/65535   [???] -->
+		<!-- Control 0x3c: +/0/65535   [???] -->
+		<!-- Control 0x3d: +/0/65535   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/0/65535   [???] -->
+		<!-- Control 0x40: +/0/65535   [???] -->
+		<!-- Control 0x41: +/0/65535   [???] -->
+		<!-- Control 0x42: +/0/65535   [???] -->
+		<!-- Control 0x43: +/0/65535   [???] -->
+		<!-- Control 0x44: +/0/65535   [???] -->
+		<!-- Control 0x45: +/0/65535   [???] -->
+		<!-- Control 0x46: +/0/65535   [???] -->
+		<!-- Control 0x47: +/0/65535   [???] -->
+		<!-- Control 0x48: +/0/65535   [???] -->
+		<!-- Control 0x49: +/0/65535   [???] -->
+		<!-- Control 0x4a: +/0/65535   [???] -->
+		<!-- Control 0x4b: +/0/65535   [???] -->
+		<!-- Control 0x4c: +/0/65535   [???] -->
+		<!-- Control 0x4d: +/0/65535   [???] -->
+		<!-- Control 0x4e: +/0/65535   [???] -->
+		<!-- Control 0x4f: +/0/65535   [???] -->
+		<!-- Control 0x50: +/0/65535   [???] -->
+		<!-- Control 0x51: +/0/65535   [???] -->
+		<!-- Control 0x52: +/98/255 C [???] -->
+		<!-- Control 0x53: +/0/65535   [???] -->
+		<!-- Control 0x54: +/0/65535   [???] -->
+		<!-- Control 0x55: +/0/65535   [???] -->
+		<!-- Control 0x56: +/0/65535   [???] -->
+		<!-- Control 0x57: +/0/65535   [???] -->
+		<!-- Control 0x58: +/0/65535   [???] -->
+		<!-- Control 0x59: +/0/65535   [???] -->
+		<!-- Control 0x5a: +/0/65535   [???] -->
+		<!-- Control 0x5b: +/0/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x5d: +/0/65535   [???] -->
+		<!-- Control 0x5e: +/0/65535   [???] -->
+		<!-- Control 0x5f: +/0/65535   [???] -->
+		<!-- Control 0x61: +/0/65535   [???] -->
+		<!-- Control 0x63: +/0/65535   [???] -->
+		<!-- Control 0x64: +/0/65535   [???] -->
+		<!-- Control 0x65: +/0/65535   [???] -->
+		<!-- Control 0x66: +/417/0 C [???] -->
+		<!-- Control 0x67: +/102/65535 C [???] -->
+		<!-- Control 0x68: +/50/65535 C [???] -->
+		<!-- Control 0x69: +/32/47   [???] -->
+		<!-- Control 0x6a: +/0/65535   [???] -->
+		<!-- Control 0x6b: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/0/65535   [???] -->
+		<!-- Control 0x6d: +/0/65535   [???] -->
+		<!-- Control 0x6e: +/0/65535   [???] -->
+		<!-- Control 0x6f: +/0/65535   [???] -->
+		<!-- Control 0x70: +/0/65535   [???] -->
+		<!-- Control 0x71: +/0/65535   [???] -->
+		<!-- Control 0x72: +/0/65535   [???] -->
+		<!-- Control 0x73: +/0/65535   [???] -->
+		<!-- Control 0x74: +/0/65535   [???] -->
+		<!-- Control 0x75: +/0/65535   [???] -->
+		<!-- Control 0x76: +/0/65535   [???] -->
+		<!-- Control 0x77: +/0/65535   [???] -->
+		<!-- Control 0x78: +/0/65535   [???] -->
+		<!-- Control 0x79: +/0/65535   [???] -->
+		<!-- Control 0x7a: +/0/65535   [???] -->
+		<!-- Control 0x7b: +/0/65535   [???] -->
+		<!-- Control 0x7c: +/0/65535   [???] -->
+		<!-- Control 0x7d: +/0/65535   [???] -->
+		<!-- Control 0x7e: +/0/65535   [???] -->
+		<!-- Control 0x7f: +/0/65535   [???] -->
+		<!-- Control 0x80: +/0/65535   [???] -->
+		<!-- Control 0x81: +/0/65535   [???] -->
+		<!-- Control 0x82: +/0/65535   [???] -->
+		<!-- Control 0x83: +/0/65535   [???] -->
+		<!-- Control 0x84: +/0/65535   [???] -->
+		<!-- Control 0x85: +/0/65535   [???] -->
+		<!-- Control 0x86: +/0/65535   [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x88: +/0/65535   [???] -->
+		<!-- Control 0x89: +/0/65535   [???] -->
+		<!-- Control 0x8a: +/0/65535   [???] -->
+		<!-- Control 0x8b: +/0/65535   [???] -->
+		<!-- Control 0x8c: +/0/65535   [???] -->
+		<!-- Control 0x8d: +/0/65535   [???] -->
+		<!-- Control 0x8e: +/0/65535   [???] -->
+		<!-- Control 0x8f: +/0/65535   [???] -->
+		<!-- Control 0x90: +/0/65535   [???] -->
+		<!-- Control 0x91: +/0/65535   [???] -->
+		<!-- Control 0x92: +/0/65535   [???] -->
+		<!-- Control 0x93: +/0/65535   [???] -->
+		<!-- Control 0x94: +/0/65535   [???] -->
+		<!-- Control 0x95: +/0/65535   [???] -->
+		<!-- Control 0x96: +/0/65535   [???] -->
+		<!-- Control 0x97: +/0/65535   [???] -->
+		<!-- Control 0x98: +/0/65535   [???] -->
+		<!-- Control 0x99: +/0/65535   [???] -->
+		<!-- Control 0x9a: +/0/65535   [???] -->
+		<!-- Control 0x9b: +/0/65535   [???] -->
+		<!-- Control 0x9c: +/0/65535   [???] -->
+		<!-- Control 0x9d: +/0/65535   [???] -->
+		<!-- Control 0x9e: +/0/65535   [???] -->
+		<!-- Control 0x9f: +/0/65535   [???] -->
+		<!-- Control 0xa0: +/0/65535   [???] -->
+		<!-- Control 0xa1: +/0/65535   [???] -->
+		<!-- Control 0xa2: +/0/65535   [???] -->
+		<!-- Control 0xa3: +/0/65535   [???] -->
+		<!-- Control 0xa4: +/0/65535   [???] -->
+		<!-- Control 0xa5: +/0/65535   [???] -->
+		<!-- Control 0xa6: +/0/65535   [???] -->
+		<!-- Control 0xa7: +/0/65535   [???] -->
+		<!-- Control 0xa8: +/0/65535   [???] -->
+		<!-- Control 0xa9: +/0/65535   [???] -->
+		<!-- Control 0xaa: +/1/1   [???] -->
+		<!-- Control 0xab: +/0/65535   [???] -->
+		<!-- Control 0xac: +/7856/4 C [???] -->
+		<!-- Control 0xad: +/0/65535   [???] -->
+		<!-- Control 0xae: +/12000/65535 C [???] -->
+		<!-- Control 0xaf: +/0/65535   [???] -->
+		<!-- Control 0xb0: +/0/65535   [???] -->
+		<!-- Control 0xb1: +/0/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/0/65535   [???] -->
+		<!-- Control 0xb4: +/0/65535   [???] -->
+		<!-- Control 0xb5: +/0/65535   [???] -->
+		<!-- Control 0xb6: +/3/3 C [???] -->
+		<!-- Control 0xb7: +/0/65535   [???] -->
+		<!-- Control 0xb8: +/0/65535   [???] -->
+		<!-- Control 0xb9: +/0/65535   [???] -->
+		<!-- Control 0xba: +/0/65535   [???] -->
+		<!-- Control 0xbb: +/0/65535   [???] -->
+		<!-- Control 0xbc: +/0/65535   [???] -->
+		<!-- Control 0xbd: +/0/65535   [???] -->
+		<!-- Control 0xbe: +/0/65535   [???] -->
+		<!-- Control 0xbf: +/0/65535   [???] -->
+		<!-- Control 0xc0: +/71/65535   [???] -->
+		<!-- Control 0xc1: +/0/65535   [???] -->
+		<!-- Control 0xc2: +/0/65535   [???] -->
+		<!-- Control 0xc3: +/0/65535   [???] -->
+		<!-- Control 0xc4: +/0/65535   [???] -->
+		<!-- Control 0xc5: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/0/65535   [???] -->
+		<!-- Control 0xc8: +/14345/39 C [???] -->
+		<!-- Control 0xc9: +/16642/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xcd: +/0/65535   [???] -->
+		<!-- Control 0xce: +/0/65535   [???] -->
+		<!-- Control 0xcf: +/0/65535   [???] -->
+		<!-- Control 0xd0: +/0/65535   [???] -->
+		<!-- Control 0xd1: +/0/65535   [???] -->
+		<!-- Control 0xd2: +/0/65535   [???] -->
+		<!-- Control 0xd3: +/0/65535   [???] -->
+		<!-- Control 0xd4: +/0/65535   [???] -->
+		<!-- Control 0xd5: +/0/65535   [???] -->
+		<!-- Control 0xd7: +/0/65535   [???] -->
+		<!-- Control 0xd8: +/0/65535   [???] -->
+		<!-- Control 0xd9: +/0/65535   [???] -->
+		<!-- Control 0xda: +/0/65535   [???] -->
+		<!-- Control 0xdb: +/0/65535   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/65535   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/65535   [???] -->
+		<!-- Control 0xe4: +/0/2 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe6: +/0/65535   [???] -->
+		<!-- Control 0xe7: +/44032/48128 C [???] -->
+		<!-- Control 0xe8: +/15/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/65535/65535 C [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xec: +/0/3846   [???] -->
+		<!-- Control 0xed: +/0/65535   [???] -->
+		<!-- Control 0xee: +/35856/35856 C [???] -->
+		<!-- Control 0xef: +/0/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/49418/65535 C [???] -->
+		<!-- Control 0xf2: +/0/65535 C [???] -->
+		<!-- Control 0xf3: +/0/65535   [???] -->
+		<!-- Control 0xf4: +/65535/65535   [???] -->
+		<!-- Control 0xf5: +/0/65535   [???] -->
+		<!-- Control 0xf6: +/0/65535   [???] -->
+		<!-- Control 0xf7: +/0/65535   [???] -->
+		<!-- Control 0xf8: +/0/65535   [???] -->
+		<!-- Control 0xf9: +/0/65535   [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/0/65535   [???] -->
+		<!-- Control 0xfc: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/116/255 C [???] -->
+		<!-- Control 0xfe: +/0/65535   [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA05E.xml
+++ b/db/monitor/DELA05E.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/17 -->
+<monitor name="Dell UltraSharp U2311H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/10/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/1 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/57/100 C [Image Lock Fine (Clock Phase)] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/15 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/100/0 [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1f: +/1/1 [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/1/15 [???] -->
+		<!-- Control 0x6e: +/1/15 [???] -->
+		<!-- Control 0x70: +/1/15 [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/56/65535 [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/1/2 [???] -->
+		<!-- Control 0xcc: +/2/11 [???] -->
+		<!-- Control 0xdc: +/0/6 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA092.xml
+++ b/db/monitor/DELA092.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/97 -->
+<monitor name="Dell U2713H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/0/65535 C [Red minimum level] -->
+		<!-- Control 0x6e: +/0/65535 C [Green minimum level] -->
+		<!-- Control 0x70: +/0/65535 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/65535 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/65535 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/65535 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/65535 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x14: +/4/65535 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x68: +/1/2   [???] -->
+		<!-- Control 0x8a: +/50/65535   [???] -->
+		<!-- Control 0x8c: +/12/65535   [???] -->
+		<!-- Control 0xac: +/23164/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb0: +/0/1   [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc0: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/269/147 C [???] -->
+		<!-- Control 0xc9: +/513/65535 C [???] -->
+		<!-- Control 0xca: +/0/2   [???] -->
+		<!-- Control 0xcc: +/2/11   [???] -->
+		<!-- Control 0xdc: +/0/65535 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe2: +/12/65535 C [???] -->
+		<!-- Control 0xe3: +/0/65535 C [???] -->
+		<!-- Control 0xe4: +/0/65535 C [???] -->
+		<!-- Control 0xf0: +/0/65535 C [???] -->
+		<!-- Control 0xf1: +/3/65535 C [???] -->
+		<!-- Control 0xf2: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA09A.xml
+++ b/db/monitor/DELA09A.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/76 -->
+<monitor name="DELL P2414H (REV A00)" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/40/100 C [Brightness] -->
+		<!-- Control 0x12: +/90/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/17 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0e: +/9554/100   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/222/100   [???] -->
+		<!-- Control 0x30: +/239/100   [???] -->
+		<!-- Control 0x3e: +/84/100   [???] -->
+		<!-- Control 0x52: +/242/255 C [???] -->
+		<!-- Control 0x6c: +/15/17   [???] -->
+		<!-- Control 0x6e: +/15/17   [???] -->
+		<!-- Control 0x70: +/15/17   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/5990/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/6582/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/34313/35 C [???] -->
+		<!-- Control 0xc9: +/256/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/11   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/22 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/3/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA0E7.xml
+++ b/db/monitor/DELA0E7.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/312 -->
+<monitor name="Dell S2417DG" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/26/100 C [Brightness] -->
+		<!-- Control 0x12: +/100/125 C [Contrast] -->
+		<!-- Control 0x16: +/97/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/94/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/90/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/0 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/0 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/0 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/0 C [Restore Factory Default Color] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/0 C [???] -->
+		<!-- Control 0x14: +/11/0 C [???] -->
+		<!-- Control 0x2e: +/0/0 C [???] -->
+		<!-- Control 0x52: +/0/0 C [???] -->
+		<!-- Control 0x59: +/127/255 C [???] -->
+		<!-- Control 0x5a: +/127/255 C [???] -->
+		<!-- Control 0x5b: +/127/255 C [???] -->
+		<!-- Control 0x5c: +/127/255 C [???] -->
+		<!-- Control 0x5d: +/127/255 C [???] -->
+		<!-- Control 0x5e: +/127/255 C [???] -->
+		<!-- Control 0x72: +/30720/0 C [???] -->
+		<!-- Control 0x8a: +/100/200 C [???] -->
+		<!-- Control 0xac: +/23244/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb6: +/515/0 C [???] -->
+		<!-- Control 0xc0: +/1462/0 C [???] -->
+		<!-- Control 0xc8: +/1279/264 C [???] -->
+		<!-- Control 0xc9: +/1119/0 C [???] -->
+		<!-- Control 0xca: +/2/0 C [???] -->
+		<!-- Control 0xdf: +/514/0 C [???] -->
+		<!-- Control 0xe0: +/0/0   [???] -->
+		<!-- Control 0xe1: +/0/0   [???] -->
+		<!-- Control 0xf9: +/48/0   [???] -->
+		<!-- Control 0xfa: +/4132/0   [???] -->
+		<!-- Control 0xfb: +/257/3855   [???] -->
+		<!-- Control 0xfc: +/521/0   [???] -->
+		<!-- Control 0xfd: +/2/0   [???] -->
+		<!-- Control 0xfe: +/1324/0   [???] -->
+		<!-- Control 0xff: +/0/24704   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA132.xml
+++ b/db/monitor/DELA132.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/230 -->
+<monitor name="Dell U3419W" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/14/100 C [Brightness] -->
+		<!-- Control 0x12: +/66/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/0/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6939/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/24438/25459   [???] -->
+		<!-- Control 0x01: +/24438/25459   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/0/1   [???] -->
+		<!-- Control 0x0f: +/0/1   [???] -->
+		<!-- Control 0x11: +/14/100   [???] -->
+		<!-- Control 0x13: +/66/100   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x15: +/12/12   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x21: +/0/1   [???] -->
+		<!-- Control 0x22: +/0/1   [???] -->
+		<!-- Control 0x23: +/0/1   [???] -->
+		<!-- Control 0x24: +/0/1   [???] -->
+		<!-- Control 0x25: +/0/1   [???] -->
+		<!-- Control 0x26: +/0/1   [???] -->
+		<!-- Control 0x27: +/0/1   [???] -->
+		<!-- Control 0x28: +/0/1   [???] -->
+		<!-- Control 0x29: +/0/1   [???] -->
+		<!-- Control 0x2a: +/0/1   [???] -->
+		<!-- Control 0x2b: +/0/1   [???] -->
+		<!-- Control 0x2c: +/0/1   [???] -->
+		<!-- Control 0x2d: +/0/1   [???] -->
+		<!-- Control 0x2e: +/0/1   [???] -->
+		<!-- Control 0x2f: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x31: +/0/1   [???] -->
+		<!-- Control 0x32: +/0/1   [???] -->
+		<!-- Control 0x33: +/0/1   [???] -->
+		<!-- Control 0x34: +/0/1   [???] -->
+		<!-- Control 0x35: +/0/1   [???] -->
+		<!-- Control 0x36: +/0/1   [???] -->
+		<!-- Control 0x37: +/0/1   [???] -->
+		<!-- Control 0x38: +/0/1   [???] -->
+		<!-- Control 0x39: +/0/1   [???] -->
+		<!-- Control 0x3a: +/0/1   [???] -->
+		<!-- Control 0x3b: +/0/1   [???] -->
+		<!-- Control 0x3c: +/0/1   [???] -->
+		<!-- Control 0x3d: +/0/1   [???] -->
+		<!-- Control 0x3e: +/0/1   [???] -->
+		<!-- Control 0x3f: +/0/1   [???] -->
+		<!-- Control 0x40: +/0/1   [???] -->
+		<!-- Control 0x41: +/0/1   [???] -->
+		<!-- Control 0x42: +/0/1   [???] -->
+		<!-- Control 0x43: +/0/1   [???] -->
+		<!-- Control 0x44: +/0/1   [???] -->
+		<!-- Control 0x45: +/0/1   [???] -->
+		<!-- Control 0x46: +/0/1   [???] -->
+		<!-- Control 0x47: +/0/1   [???] -->
+		<!-- Control 0x48: +/0/1   [???] -->
+		<!-- Control 0x49: +/0/1   [???] -->
+		<!-- Control 0x4a: +/0/1   [???] -->
+		<!-- Control 0x4b: +/0/1   [???] -->
+		<!-- Control 0x4c: +/0/1   [???] -->
+		<!-- Control 0x4d: +/0/1   [???] -->
+		<!-- Control 0x4e: +/0/1   [???] -->
+		<!-- Control 0x4f: +/0/1   [???] -->
+		<!-- Control 0x50: +/0/1   [???] -->
+		<!-- Control 0x51: +/0/1   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x53: +/96/255   [???] -->
+		<!-- Control 0x54: +/96/255   [???] -->
+		<!-- Control 0x55: +/96/255   [???] -->
+		<!-- Control 0x56: +/96/255   [???] -->
+		<!-- Control 0x57: +/96/255   [???] -->
+		<!-- Control 0x58: +/96/255   [???] -->
+		<!-- Control 0x59: +/96/255   [???] -->
+		<!-- Control 0x5a: +/96/255   [???] -->
+		<!-- Control 0x5b: +/96/255   [???] -->
+		<!-- Control 0x5c: +/96/255   [???] -->
+		<!-- Control 0x5d: +/96/255   [???] -->
+		<!-- Control 0x5e: +/96/255   [???] -->
+		<!-- Control 0x5f: +/96/255   [???] -->
+		<!-- Control 0x61: +/6939/4626   [???] -->
+		<!-- Control 0x63: +/0/100   [???] -->
+		<!-- Control 0x64: +/0/100   [???] -->
+		<!-- Control 0x65: +/0/100   [???] -->
+		<!-- Control 0x66: +/0/100   [???] -->
+		<!-- Control 0x67: +/0/100   [???] -->
+		<!-- Control 0x68: +/0/100   [???] -->
+		<!-- Control 0x69: +/0/100   [???] -->
+		<!-- Control 0x6a: +/0/100   [???] -->
+		<!-- Control 0x6b: +/0/100   [???] -->
+		<!-- Control 0x6c: +/0/100   [???] -->
+		<!-- Control 0x6d: +/0/100   [???] -->
+		<!-- Control 0x6e: +/0/100   [???] -->
+		<!-- Control 0x6f: +/0/100   [???] -->
+		<!-- Control 0x70: +/0/100   [???] -->
+		<!-- Control 0x71: +/0/100   [???] -->
+		<!-- Control 0x72: +/0/100   [???] -->
+		<!-- Control 0x73: +/0/100   [???] -->
+		<!-- Control 0x74: +/0/100   [???] -->
+		<!-- Control 0x75: +/0/100   [???] -->
+		<!-- Control 0x76: +/0/100   [???] -->
+		<!-- Control 0x77: +/0/100   [???] -->
+		<!-- Control 0x78: +/0/100   [???] -->
+		<!-- Control 0x79: +/0/100   [???] -->
+		<!-- Control 0x7a: +/0/100   [???] -->
+		<!-- Control 0x7b: +/0/100   [???] -->
+		<!-- Control 0x7c: +/0/100   [???] -->
+		<!-- Control 0x7d: +/0/100   [???] -->
+		<!-- Control 0x7e: +/0/100   [???] -->
+		<!-- Control 0x7f: +/0/100   [???] -->
+		<!-- Control 0x80: +/0/100   [???] -->
+		<!-- Control 0x81: +/0/100   [???] -->
+		<!-- Control 0x82: +/0/100   [???] -->
+		<!-- Control 0x83: +/0/100   [???] -->
+		<!-- Control 0x84: +/0/100   [???] -->
+		<!-- Control 0x85: +/0/100   [???] -->
+		<!-- Control 0x86: +/0/100   [???] -->
+		<!-- Control 0x87: +/0/100   [???] -->
+		<!-- Control 0x88: +/0/100   [???] -->
+		<!-- Control 0x89: +/0/100   [???] -->
+		<!-- Control 0x8a: +/0/100   [???] -->
+		<!-- Control 0x8b: +/0/100   [???] -->
+		<!-- Control 0x8c: +/0/100   [???] -->
+		<!-- Control 0x8d: +/0/100   [???] -->
+		<!-- Control 0x8e: +/0/100   [???] -->
+		<!-- Control 0x8f: +/0/100   [???] -->
+		<!-- Control 0x90: +/0/100   [???] -->
+		<!-- Control 0x91: +/0/100   [???] -->
+		<!-- Control 0x92: +/0/100   [???] -->
+		<!-- Control 0x93: +/0/100   [???] -->
+		<!-- Control 0x94: +/0/100   [???] -->
+		<!-- Control 0x95: +/0/100   [???] -->
+		<!-- Control 0x96: +/0/100   [???] -->
+		<!-- Control 0x97: +/0/100   [???] -->
+		<!-- Control 0x98: +/0/100   [???] -->
+		<!-- Control 0x99: +/0/100   [???] -->
+		<!-- Control 0x9a: +/0/100   [???] -->
+		<!-- Control 0x9b: +/0/100   [???] -->
+		<!-- Control 0x9c: +/0/100   [???] -->
+		<!-- Control 0x9d: +/0/100   [???] -->
+		<!-- Control 0x9e: +/0/100   [???] -->
+		<!-- Control 0x9f: +/0/100   [???] -->
+		<!-- Control 0xa0: +/0/100   [???] -->
+		<!-- Control 0xa1: +/0/100   [???] -->
+		<!-- Control 0xa2: +/0/100   [???] -->
+		<!-- Control 0xa3: +/0/100   [???] -->
+		<!-- Control 0xa4: +/0/100   [???] -->
+		<!-- Control 0xa5: +/0/100   [???] -->
+		<!-- Control 0xa6: +/0/100   [???] -->
+		<!-- Control 0xa7: +/0/100   [???] -->
+		<!-- Control 0xa8: +/0/100   [???] -->
+		<!-- Control 0xa9: +/0/100   [???] -->
+		<!-- Control 0xaa: +/0/100   [???] -->
+		<!-- Control 0xab: +/0/100   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xad: +/23364/1   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/5426/65535   [???] -->
+		<!-- Control 0xc1: +/5426/65535   [???] -->
+		<!-- Control 0xc2: +/5426/65535   [???] -->
+		<!-- Control 0xc3: +/5426/65535   [???] -->
+		<!-- Control 0xc4: +/5426/65535   [???] -->
+		<!-- Control 0xc5: +/5426/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/4361/17 C [???] -->
+		<!-- Control 0xc9: +/16647/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcb: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xcd: +/2/13   [???] -->
+		<!-- Control 0xce: +/2/13   [???] -->
+		<!-- Control 0xcf: +/2/13   [???] -->
+		<!-- Control 0xd0: +/2/13   [???] -->
+		<!-- Control 0xd1: +/2/13   [???] -->
+		<!-- Control 0xd2: +/2/13   [???] -->
+		<!-- Control 0xd3: +/2/13   [???] -->
+		<!-- Control 0xd4: +/2/13   [???] -->
+		<!-- Control 0xd5: +/2/13   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/255 C [???] -->
+		<!-- Control 0xe3: +/20/255   [???] -->
+		<!-- Control 0xe4: +/0/2 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe6: +/0/255   [???] -->
+		<!-- Control 0xe7: +/6/170 C [???] -->
+		<!-- Control 0xe8: +/15/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/64514/64514 C [???] -->
+		<!-- Control 0xeb: +/64514/64514   [???] -->
+		<!-- Control 0xec: +/64514/64514   [???] -->
+		<!-- Control 0xed: +/64514/64514   [???] -->
+		<!-- Control 0xee: +/64514/64514   [???] -->
+		<!-- Control 0xef: +/64514/64514   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/267/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf3: +/1440/3440   [???] -->
+		<!-- Control 0xf4: +/1440/3440   [???] -->
+		<!-- Control 0xf5: +/1440/3440   [???] -->
+		<!-- Control 0xf6: +/1440/3440   [???] -->
+		<!-- Control 0xf7: +/1440/3440   [???] -->
+		<!-- Control 0xf8: +/1440/3440   [???] -->
+		<!-- Control 0xf9: +/1440/3440   [???] -->
+		<!-- Control 0xfa: +/1440/3440   [???] -->
+		<!-- Control 0xfb: +/0/1   [???] -->
+		<!-- Control 0xfc: +/0/1   [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+		<!-- Control 0xfe: +/19/255   [???] -->
+		<!-- Control 0xff: +/19/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA150.xml
+++ b/db/monitor/DELA150.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/314 -->
+<monitor name="Dell U2520D" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6939/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/4 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/3/5 C [DPMS Control] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/29791/29541   [???] -->
+		<!-- Control 0x01: +/29791/29541   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/50/100   [???] -->
+		<!-- Control 0x11: +/75/100   [???] -->
+		<!-- Control 0x13: +/75/100   [???] -->
+		<!-- Control 0x14: +/75/100 C [???] -->
+		<!-- Control 0x15: +/75/100   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x21: +/50/100   [???] -->
+		<!-- Control 0x22: +/50/100   [???] -->
+		<!-- Control 0x23: +/50/100   [???] -->
+		<!-- Control 0x24: +/50/100   [???] -->
+		<!-- Control 0x25: +/50/100   [???] -->
+		<!-- Control 0x26: +/50/100   [???] -->
+		<!-- Control 0x27: +/50/100   [???] -->
+		<!-- Control 0x28: +/50/100   [???] -->
+		<!-- Control 0x29: +/50/100   [???] -->
+		<!-- Control 0x2a: +/50/100   [???] -->
+		<!-- Control 0x2b: +/50/100   [???] -->
+		<!-- Control 0x2c: +/50/100   [???] -->
+		<!-- Control 0x2d: +/50/100   [???] -->
+		<!-- Control 0x2e: +/50/100   [???] -->
+		<!-- Control 0x2f: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x31: +/50/100   [???] -->
+		<!-- Control 0x32: +/50/100   [???] -->
+		<!-- Control 0x33: +/50/100   [???] -->
+		<!-- Control 0x34: +/50/100   [???] -->
+		<!-- Control 0x35: +/50/100   [???] -->
+		<!-- Control 0x36: +/50/100   [???] -->
+		<!-- Control 0x37: +/50/100   [???] -->
+		<!-- Control 0x38: +/50/100   [???] -->
+		<!-- Control 0x39: +/50/100   [???] -->
+		<!-- Control 0x3a: +/50/100   [???] -->
+		<!-- Control 0x3b: +/50/100   [???] -->
+		<!-- Control 0x3c: +/50/100   [???] -->
+		<!-- Control 0x3d: +/50/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/50/100   [???] -->
+		<!-- Control 0x40: +/50/100   [???] -->
+		<!-- Control 0x41: +/50/100   [???] -->
+		<!-- Control 0x42: +/50/100   [???] -->
+		<!-- Control 0x43: +/50/100   [???] -->
+		<!-- Control 0x44: +/50/100   [???] -->
+		<!-- Control 0x45: +/50/100   [???] -->
+		<!-- Control 0x46: +/50/100   [???] -->
+		<!-- Control 0x47: +/50/100   [???] -->
+		<!-- Control 0x48: +/50/100   [???] -->
+		<!-- Control 0x49: +/50/100   [???] -->
+		<!-- Control 0x4a: +/50/100   [???] -->
+		<!-- Control 0x4b: +/50/100   [???] -->
+		<!-- Control 0x4c: +/50/100   [???] -->
+		<!-- Control 0x4d: +/50/100   [???] -->
+		<!-- Control 0x4e: +/50/100   [???] -->
+		<!-- Control 0x4f: +/50/100   [???] -->
+		<!-- Control 0x50: +/50/100   [???] -->
+		<!-- Control 0x51: +/50/100   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x53: +/96/255   [???] -->
+		<!-- Control 0x54: +/96/255   [???] -->
+		<!-- Control 0x55: +/96/255   [???] -->
+		<!-- Control 0x56: +/96/255   [???] -->
+		<!-- Control 0x57: +/96/255   [???] -->
+		<!-- Control 0x58: +/96/255   [???] -->
+		<!-- Control 0x59: +/96/255   [???] -->
+		<!-- Control 0x5a: +/96/255   [???] -->
+		<!-- Control 0x5b: +/96/255   [???] -->
+		<!-- Control 0x5c: +/96/255   [???] -->
+		<!-- Control 0x5d: +/96/255   [???] -->
+		<!-- Control 0x5e: +/96/255   [???] -->
+		<!-- Control 0x5f: +/96/255   [???] -->
+		<!-- Control 0x61: +/6939/4626   [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/100/100   [???] -->
+		<!-- Control 0x6d: +/100/100   [???] -->
+		<!-- Control 0x6e: +/100/100   [???] -->
+		<!-- Control 0x6f: +/100/100   [???] -->
+		<!-- Control 0x70: +/100/100   [???] -->
+		<!-- Control 0x71: +/100/100   [???] -->
+		<!-- Control 0x72: +/100/100   [???] -->
+		<!-- Control 0x73: +/100/100   [???] -->
+		<!-- Control 0x74: +/100/100   [???] -->
+		<!-- Control 0x75: +/100/100   [???] -->
+		<!-- Control 0x76: +/100/100   [???] -->
+		<!-- Control 0x77: +/100/100   [???] -->
+		<!-- Control 0x78: +/100/100   [???] -->
+		<!-- Control 0x79: +/100/100   [???] -->
+		<!-- Control 0x7a: +/100/100   [???] -->
+		<!-- Control 0x7b: +/100/100   [???] -->
+		<!-- Control 0x7c: +/100/100   [???] -->
+		<!-- Control 0x7d: +/100/100   [???] -->
+		<!-- Control 0x7e: +/100/100   [???] -->
+		<!-- Control 0x7f: +/100/100   [???] -->
+		<!-- Control 0x80: +/100/100   [???] -->
+		<!-- Control 0x81: +/100/100   [???] -->
+		<!-- Control 0x82: +/100/100   [???] -->
+		<!-- Control 0x83: +/100/100   [???] -->
+		<!-- Control 0x84: +/100/100   [???] -->
+		<!-- Control 0x85: +/100/100   [???] -->
+		<!-- Control 0x86: +/100/100   [???] -->
+		<!-- Control 0x87: +/100/100   [???] -->
+		<!-- Control 0x88: +/100/100   [???] -->
+		<!-- Control 0x89: +/100/100   [???] -->
+		<!-- Control 0x8a: +/100/100   [???] -->
+		<!-- Control 0x8b: +/100/100   [???] -->
+		<!-- Control 0x8c: +/100/100   [???] -->
+		<!-- Control 0x8d: +/100/100   [???] -->
+		<!-- Control 0x8e: +/100/100   [???] -->
+		<!-- Control 0x8f: +/100/100   [???] -->
+		<!-- Control 0x90: +/100/100   [???] -->
+		<!-- Control 0x91: +/100/100   [???] -->
+		<!-- Control 0x92: +/100/100   [???] -->
+		<!-- Control 0x93: +/100/100   [???] -->
+		<!-- Control 0x94: +/100/100   [???] -->
+		<!-- Control 0x95: +/100/100   [???] -->
+		<!-- Control 0x96: +/100/100   [???] -->
+		<!-- Control 0x97: +/100/100   [???] -->
+		<!-- Control 0x98: +/100/100   [???] -->
+		<!-- Control 0x99: +/100/100   [???] -->
+		<!-- Control 0x9a: +/100/100   [???] -->
+		<!-- Control 0x9b: +/100/100   [???] -->
+		<!-- Control 0x9c: +/100/100   [???] -->
+		<!-- Control 0x9d: +/100/100   [???] -->
+		<!-- Control 0x9e: +/100/100   [???] -->
+		<!-- Control 0x9f: +/100/100   [???] -->
+		<!-- Control 0xa0: +/100/100   [???] -->
+		<!-- Control 0xa1: +/100/100   [???] -->
+		<!-- Control 0xa2: +/100/100   [???] -->
+		<!-- Control 0xa3: +/100/100   [???] -->
+		<!-- Control 0xa4: +/100/100   [???] -->
+		<!-- Control 0xa5: +/100/100   [???] -->
+		<!-- Control 0xa6: +/100/100   [???] -->
+		<!-- Control 0xa7: +/100/100   [???] -->
+		<!-- Control 0xa8: +/100/100   [???] -->
+		<!-- Control 0xa9: +/100/100   [???] -->
+		<!-- Control 0xab: +/1/4   [???] -->
+		<!-- Control 0xac: +/9064/1 C [???] -->
+		<!-- Control 0xad: +/9064/1   [???] -->
+		<!-- Control 0xae: +/5990/65535 C [???] -->
+		<!-- Control 0xaf: +/5990/65535   [???] -->
+		<!-- Control 0xb0: +/5990/65535   [???] -->
+		<!-- Control 0xb1: +/5990/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/10/65535   [???] -->
+		<!-- Control 0xc1: +/10/65535   [???] -->
+		<!-- Control 0xc2: +/10/65535   [???] -->
+		<!-- Control 0xc3: +/10/65535   [???] -->
+		<!-- Control 0xc4: +/10/65535   [???] -->
+		<!-- Control 0xc5: +/10/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/5897/39 C [???] -->
+		<!-- Control 0xc9: +/16643/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xcd: +/2/13   [???] -->
+		<!-- Control 0xce: +/2/13   [???] -->
+		<!-- Control 0xcf: +/2/13   [???] -->
+		<!-- Control 0xd0: +/2/13   [???] -->
+		<!-- Control 0xd1: +/2/13   [???] -->
+		<!-- Control 0xd2: +/2/13   [???] -->
+		<!-- Control 0xd3: +/2/13   [???] -->
+		<!-- Control 0xd4: +/2/13   [???] -->
+		<!-- Control 0xd5: +/2/13   [???] -->
+		<!-- Control 0xd7: +/3/5   [???] -->
+		<!-- Control 0xd8: +/3/5   [???] -->
+		<!-- Control 0xd9: +/3/5   [???] -->
+		<!-- Control 0xda: +/3/5   [???] -->
+		<!-- Control 0xdb: +/3/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/255   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/255   [???] -->
+		<!-- Control 0xe6: +/0/255   [???] -->
+		<!-- Control 0xe7: +/2/63   [???] -->
+		<!-- Control 0xe8: +/15/65535   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xea: +/64514/65535 C [???] -->
+		<!-- Control 0xeb: +/64514/65535   [???] -->
+		<!-- Control 0xec: +/64514/65535   [???] -->
+		<!-- Control 0xed: +/64514/65535   [???] -->
+		<!-- Control 0xee: +/64514/65535   [???] -->
+		<!-- Control 0xef: +/64514/65535   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf4: +/1200/1408   [???] -->
+		<!-- Control 0xf5: +/1200/1408   [???] -->
+		<!-- Control 0xf6: +/1200/1408   [???] -->
+		<!-- Control 0xf7: +/1200/1408   [???] -->
+		<!-- Control 0xf8: +/1200/1408   [???] -->
+		<!-- Control 0xf9: +/1200/1408   [???] -->
+		<!-- Control 0xfa: +/1200/1408   [???] -->
+		<!-- Control 0xfb: +/1200/1408   [???] -->
+		<!-- Control 0xfc: +/1200/1408   [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+		<!-- Control 0xfe: +/21/255   [???] -->
+		<!-- Control 0xff: +/21/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA185.xml
+++ b/db/monitor/DELA185.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/194 -->
+<monitor name="Dell U3421WE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6939/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6003/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16642/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe4: +/1/1 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe7: +/65282/65450 C [???] -->
+		<!-- Control 0xe8: +/27/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/267/267 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xfe: +/147/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA198.xml
+++ b/db/monitor/DELA198.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/310 -->
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/318 -->
+<monitor name="Dell S2721QS" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/26/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/52/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3855/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/18/255 C [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/2228/2 C [???] -->
+		<!-- Control 0xae: +/5999/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/245/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16643/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe6: +/1/1   [???] -->
+		<!-- Control 0xe8: +/15/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/65024/65024 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/27/27 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA1AE.xml
+++ b/db/monitor/DELA1AE.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/224 -->
+<monitor name="Dell U3821DW" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3855/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/32864/1 C [???] -->
+		<!-- Control 0xae: +/5978/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/268/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16641/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/15/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/1 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe7: +/65282/65450 C [???] -->
+		<!-- Control 0xe8: +/27/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/267/267 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xfe: +/149/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA1AF.xml
+++ b/db/monitor/DELA1AF.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/253 -->
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/323 -->
+<monitor name="Dell U3821DW" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/65/100 C [Brightness] -->
+		<!-- Control 0x12: +/65/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/1/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/6939/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+		<!-- Control 0x60: +/6927/14 C [Input Source Select (Main)] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/18/255 C [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/32864/1 C [???] -->
+		<!-- Control 0xae: +/5978/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/2663/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/16644/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/0/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/1 C [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe7: +/65282/65450 C [???] -->
+		<!-- Control 0xe8: +/18/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/16651/16651 C [???] -->
+		<!-- Control 0xf2: +/0/65280 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xfe: +/149/65535   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0xc0: +/1071/65535   [???] -->
+		<!-- Control 0xc9: +/16643/65535 C [???] -->
+		<!-- Control 0xcc: +/4/14 C [???] -->
+		<!-- Control 0xe4: +/1/1 C [???] -->
+		<!-- Control 0xe8: +/15/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELA1D6.xml
+++ b/db/monitor/DELA1D6.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/206 -->
+<monitor name="Dell S2722QC" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/90/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/90/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4369/6939 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/65535   [???] -->
+		<!-- Control 0x01: +/0/65535   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/65535   [???] -->
+		<!-- Control 0x09: +/0/65535   [???] -->
+		<!-- Control 0x0a: +/0/65535   [???] -->
+		<!-- Control 0x0b: +/0/65535   [???] -->
+		<!-- Control 0x0c: +/0/65535   [???] -->
+		<!-- Control 0x0d: +/0/65535   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/0/65535   [???] -->
+		<!-- Control 0x11: +/0/65535   [???] -->
+		<!-- Control 0x13: +/0/65535   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x15: +/0/65535   [???] -->
+		<!-- Control 0x17: +/0/65535   [???] -->
+		<!-- Control 0x19: +/0/65535   [???] -->
+		<!-- Control 0x1b: +/0/65535   [???] -->
+		<!-- Control 0x1c: +/0/65535   [???] -->
+		<!-- Control 0x1d: +/0/65535   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x21: +/0/65535   [???] -->
+		<!-- Control 0x22: +/0/65535   [???] -->
+		<!-- Control 0x23: +/0/65535   [???] -->
+		<!-- Control 0x24: +/0/65535   [???] -->
+		<!-- Control 0x25: +/0/65535   [???] -->
+		<!-- Control 0x26: +/0/65535   [???] -->
+		<!-- Control 0x27: +/0/65535   [???] -->
+		<!-- Control 0x28: +/0/65535   [???] -->
+		<!-- Control 0x29: +/0/65535   [???] -->
+		<!-- Control 0x2a: +/0/65535   [???] -->
+		<!-- Control 0x2b: +/0/65535   [???] -->
+		<!-- Control 0x2c: +/0/65535   [???] -->
+		<!-- Control 0x2d: +/0/65535   [???] -->
+		<!-- Control 0x2e: +/0/65535   [???] -->
+		<!-- Control 0x2f: +/0/65535   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x31: +/0/65535   [???] -->
+		<!-- Control 0x32: +/0/65535   [???] -->
+		<!-- Control 0x33: +/0/65535   [???] -->
+		<!-- Control 0x34: +/0/65535   [???] -->
+		<!-- Control 0x35: +/0/65535   [???] -->
+		<!-- Control 0x36: +/0/65535   [???] -->
+		<!-- Control 0x37: +/0/65535   [???] -->
+		<!-- Control 0x38: +/0/65535   [???] -->
+		<!-- Control 0x39: +/0/65535   [???] -->
+		<!-- Control 0x3a: +/0/65535   [???] -->
+		<!-- Control 0x3b: +/0/65535   [???] -->
+		<!-- Control 0x3c: +/0/65535   [???] -->
+		<!-- Control 0x3d: +/0/65535   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/0/65535   [???] -->
+		<!-- Control 0x40: +/0/65535   [???] -->
+		<!-- Control 0x41: +/0/65535   [???] -->
+		<!-- Control 0x42: +/0/65535   [???] -->
+		<!-- Control 0x43: +/0/65535   [???] -->
+		<!-- Control 0x44: +/0/65535   [???] -->
+		<!-- Control 0x45: +/0/65535   [???] -->
+		<!-- Control 0x46: +/0/65535   [???] -->
+		<!-- Control 0x47: +/0/65535   [???] -->
+		<!-- Control 0x48: +/0/65535   [???] -->
+		<!-- Control 0x49: +/0/65535   [???] -->
+		<!-- Control 0x4a: +/0/65535   [???] -->
+		<!-- Control 0x4b: +/0/65535   [???] -->
+		<!-- Control 0x4c: +/0/65535   [???] -->
+		<!-- Control 0x4d: +/0/65535   [???] -->
+		<!-- Control 0x4e: +/0/65535   [???] -->
+		<!-- Control 0x4f: +/0/65535   [???] -->
+		<!-- Control 0x50: +/0/65535   [???] -->
+		<!-- Control 0x51: +/0/65535   [???] -->
+		<!-- Control 0x52: +/226/255 C [???] -->
+		<!-- Control 0x53: +/0/65535   [???] -->
+		<!-- Control 0x54: +/0/65535   [???] -->
+		<!-- Control 0x55: +/0/65535   [???] -->
+		<!-- Control 0x56: +/0/65535   [???] -->
+		<!-- Control 0x57: +/0/65535   [???] -->
+		<!-- Control 0x58: +/0/65535   [???] -->
+		<!-- Control 0x59: +/0/65535   [???] -->
+		<!-- Control 0x5a: +/0/65535   [???] -->
+		<!-- Control 0x5b: +/0/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x5d: +/0/65535   [???] -->
+		<!-- Control 0x5e: +/0/65535   [???] -->
+		<!-- Control 0x5f: +/0/65535   [???] -->
+		<!-- Control 0x61: +/0/65535   [???] -->
+		<!-- Control 0x63: +/0/65535   [???] -->
+		<!-- Control 0x64: +/0/65535   [???] -->
+		<!-- Control 0x65: +/0/65535   [???] -->
+		<!-- Control 0x66: +/0/65535   [???] -->
+		<!-- Control 0x67: +/0/65535   [???] -->
+		<!-- Control 0x68: +/0/65535   [???] -->
+		<!-- Control 0x69: +/0/65535   [???] -->
+		<!-- Control 0x6a: +/0/65535   [???] -->
+		<!-- Control 0x6b: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/0/65535   [???] -->
+		<!-- Control 0x6d: +/0/65535   [???] -->
+		<!-- Control 0x6e: +/0/65535   [???] -->
+		<!-- Control 0x6f: +/0/65535   [???] -->
+		<!-- Control 0x70: +/0/65535   [???] -->
+		<!-- Control 0x71: +/0/65535   [???] -->
+		<!-- Control 0x72: +/0/65535   [???] -->
+		<!-- Control 0x73: +/0/65535   [???] -->
+		<!-- Control 0x74: +/0/65535   [???] -->
+		<!-- Control 0x75: +/0/65535   [???] -->
+		<!-- Control 0x76: +/0/65535   [???] -->
+		<!-- Control 0x77: +/0/65535   [???] -->
+		<!-- Control 0x78: +/0/65535   [???] -->
+		<!-- Control 0x79: +/0/65535   [???] -->
+		<!-- Control 0x7a: +/0/65535   [???] -->
+		<!-- Control 0x7b: +/0/65535   [???] -->
+		<!-- Control 0x7c: +/0/65535   [???] -->
+		<!-- Control 0x7d: +/0/65535   [???] -->
+		<!-- Control 0x7e: +/0/65535   [???] -->
+		<!-- Control 0x7f: +/0/65535   [???] -->
+		<!-- Control 0x80: +/0/65535   [???] -->
+		<!-- Control 0x81: +/0/65535   [???] -->
+		<!-- Control 0x82: +/0/65535   [???] -->
+		<!-- Control 0x83: +/0/65535   [???] -->
+		<!-- Control 0x84: +/0/65535   [???] -->
+		<!-- Control 0x85: +/0/65535   [???] -->
+		<!-- Control 0x86: +/0/65535   [???] -->
+		<!-- Control 0x87: +/0/65535   [???] -->
+		<!-- Control 0x88: +/0/65535   [???] -->
+		<!-- Control 0x89: +/0/65535   [???] -->
+		<!-- Control 0x8a: +/0/65535   [???] -->
+		<!-- Control 0x8b: +/0/65535   [???] -->
+		<!-- Control 0x8c: +/0/65535   [???] -->
+		<!-- Control 0x8d: +/0/65535   [???] -->
+		<!-- Control 0x8e: +/0/65535   [???] -->
+		<!-- Control 0x8f: +/0/65535   [???] -->
+		<!-- Control 0x90: +/0/65535   [???] -->
+		<!-- Control 0x91: +/0/65535   [???] -->
+		<!-- Control 0x92: +/0/65535   [???] -->
+		<!-- Control 0x93: +/0/65535   [???] -->
+		<!-- Control 0x94: +/0/65535   [???] -->
+		<!-- Control 0x95: +/0/65535   [???] -->
+		<!-- Control 0x96: +/0/65535   [???] -->
+		<!-- Control 0x97: +/0/65535   [???] -->
+		<!-- Control 0x98: +/0/65535   [???] -->
+		<!-- Control 0x99: +/0/65535   [???] -->
+		<!-- Control 0x9a: +/0/65535   [???] -->
+		<!-- Control 0x9b: +/0/65535   [???] -->
+		<!-- Control 0x9c: +/0/65535   [???] -->
+		<!-- Control 0x9d: +/0/65535   [???] -->
+		<!-- Control 0x9e: +/0/65535   [???] -->
+		<!-- Control 0x9f: +/0/65535   [???] -->
+		<!-- Control 0xa0: +/0/65535   [???] -->
+		<!-- Control 0xa1: +/0/65535   [???] -->
+		<!-- Control 0xa2: +/0/65535   [???] -->
+		<!-- Control 0xa3: +/0/65535   [???] -->
+		<!-- Control 0xa4: +/0/65535   [???] -->
+		<!-- Control 0xa5: +/0/65535   [???] -->
+		<!-- Control 0xa6: +/0/65535   [???] -->
+		<!-- Control 0xa7: +/0/65535   [???] -->
+		<!-- Control 0xa8: +/0/65535   [???] -->
+		<!-- Control 0xa9: +/0/65535   [???] -->
+		<!-- Control 0xaa: +/1/4   [???] -->
+		<!-- Control 0xab: +/0/65535   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xad: +/0/65535   [???] -->
+		<!-- Control 0xae: +/3000/65535 C [???] -->
+		<!-- Control 0xaf: +/0/65535   [???] -->
+		<!-- Control 0xb0: +/0/65535   [???] -->
+		<!-- Control 0xb1: +/0/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/0/65535   [???] -->
+		<!-- Control 0xb4: +/0/65535   [???] -->
+		<!-- Control 0xb5: +/0/65535   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/0/65535   [???] -->
+		<!-- Control 0xb8: +/0/65535   [???] -->
+		<!-- Control 0xb9: +/0/65535   [???] -->
+		<!-- Control 0xba: +/0/65535   [???] -->
+		<!-- Control 0xbb: +/0/65535   [???] -->
+		<!-- Control 0xbc: +/0/65535   [???] -->
+		<!-- Control 0xbd: +/0/65535   [???] -->
+		<!-- Control 0xbe: +/0/65535   [???] -->
+		<!-- Control 0xbf: +/0/65535   [???] -->
+		<!-- Control 0xc0: +/1/65535   [???] -->
+		<!-- Control 0xc1: +/0/65535   [???] -->
+		<!-- Control 0xc2: +/0/65535   [???] -->
+		<!-- Control 0xc3: +/0/65535   [???] -->
+		<!-- Control 0xc4: +/0/65535   [???] -->
+		<!-- Control 0xc5: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/0/65535   [???] -->
+		<!-- Control 0xc8: +/38921/39 C [???] -->
+		<!-- Control 0xc9: +/16642/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcb: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xcd: +/0/65535   [???] -->
+		<!-- Control 0xce: +/0/65535   [???] -->
+		<!-- Control 0xcf: +/0/65535   [???] -->
+		<!-- Control 0xd0: +/0/65535   [???] -->
+		<!-- Control 0xd1: +/0/65535   [???] -->
+		<!-- Control 0xd2: +/0/65535   [???] -->
+		<!-- Control 0xd3: +/0/65535   [???] -->
+		<!-- Control 0xd4: +/0/65535   [???] -->
+		<!-- Control 0xd5: +/0/65535   [???] -->
+		<!-- Control 0xd7: +/0/65535   [???] -->
+		<!-- Control 0xd8: +/0/65535   [???] -->
+		<!-- Control 0xd9: +/0/65535   [???] -->
+		<!-- Control 0xda: +/0/65535   [???] -->
+		<!-- Control 0xdb: +/0/65535   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/65535   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/33/255 C [???] -->
+		<!-- Control 0xe3: +/0/65535 C [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/255 C [???] -->
+		<!-- Control 0xe6: +/1/0   [???] -->
+		<!-- Control 0xe7: +/42/63   [???] -->
+		<!-- Control 0xe8: +/18/65535 C [???] -->
+		<!-- Control 0xe9: +/0/255 C [???] -->
+		<!-- Control 0xea: +/64513/65535 C [???] -->
+		<!-- Control 0xeb: +/64513/65535   [???] -->
+		<!-- Control 0xec: +/64513/65535   [???] -->
+		<!-- Control 0xed: +/64513/65535   [???] -->
+		<!-- Control 0xee: +/0/65535   [???] -->
+		<!-- Control 0xef: +/0/255   [???] -->
+		<!-- Control 0xf0: +/16/255 C [???] -->
+		<!-- Control 0xf1: +/27/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf4: +/0/5   [???] -->
+		<!-- Control 0xf5: +/0/65535   [???] -->
+		<!-- Control 0xf6: +/0/65535   [???] -->
+		<!-- Control 0xf7: +/0/65535   [???] -->
+		<!-- Control 0xf8: +/0/65535   [???] -->
+		<!-- Control 0xf9: +/0/65535   [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/0/65535   [???] -->
+		<!-- Control 0xfc: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/98/255 C [???] -->
+		<!-- Control 0xfe: +/40/255   [???] -->
+		<!-- Control 0xff: +/40/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELD0C1.xml
+++ b/db/monitor/DELD0C1.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/148 -->
+<monitor name="Dell P2418D" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3855/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/4 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/99/255   [???] -->
+		<!-- Control 0x01: +/99/255   [???] -->
+		<!-- Control 0x03: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/0/1   [???] -->
+		<!-- Control 0x0f: +/0/1   [???] -->
+		<!-- Control 0x11: +/50/100   [???] -->
+		<!-- Control 0x13: +/75/100   [???] -->
+		<!-- Control 0x14: +/4/12 C [???] -->
+		<!-- Control 0x15: +/4/12   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x21: +/0/1   [???] -->
+		<!-- Control 0x22: +/0/1   [???] -->
+		<!-- Control 0x23: +/0/1   [???] -->
+		<!-- Control 0x24: +/0/1   [???] -->
+		<!-- Control 0x25: +/0/1   [???] -->
+		<!-- Control 0x26: +/0/1   [???] -->
+		<!-- Control 0x27: +/0/1   [???] -->
+		<!-- Control 0x28: +/0/1   [???] -->
+		<!-- Control 0x29: +/0/1   [???] -->
+		<!-- Control 0x2a: +/0/1   [???] -->
+		<!-- Control 0x2b: +/0/1   [???] -->
+		<!-- Control 0x2c: +/0/1   [???] -->
+		<!-- Control 0x2d: +/0/1   [???] -->
+		<!-- Control 0x2e: +/0/1   [???] -->
+		<!-- Control 0x2f: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x31: +/0/1   [???] -->
+		<!-- Control 0x32: +/0/1   [???] -->
+		<!-- Control 0x33: +/0/1   [???] -->
+		<!-- Control 0x34: +/0/1   [???] -->
+		<!-- Control 0x35: +/0/1   [???] -->
+		<!-- Control 0x36: +/0/1   [???] -->
+		<!-- Control 0x37: +/0/1   [???] -->
+		<!-- Control 0x38: +/0/1   [???] -->
+		<!-- Control 0x39: +/0/1   [???] -->
+		<!-- Control 0x3a: +/0/1   [???] -->
+		<!-- Control 0x3b: +/0/1   [???] -->
+		<!-- Control 0x3c: +/0/1   [???] -->
+		<!-- Control 0x3d: +/0/1   [???] -->
+		<!-- Control 0x3e: +/0/1   [???] -->
+		<!-- Control 0x3f: +/0/1   [???] -->
+		<!-- Control 0x40: +/0/1   [???] -->
+		<!-- Control 0x41: +/0/1   [???] -->
+		<!-- Control 0x42: +/0/1   [???] -->
+		<!-- Control 0x43: +/0/1   [???] -->
+		<!-- Control 0x44: +/0/1   [???] -->
+		<!-- Control 0x45: +/0/1   [???] -->
+		<!-- Control 0x46: +/0/1   [???] -->
+		<!-- Control 0x47: +/0/1   [???] -->
+		<!-- Control 0x48: +/0/1   [???] -->
+		<!-- Control 0x49: +/0/1   [???] -->
+		<!-- Control 0x4a: +/0/1   [???] -->
+		<!-- Control 0x4b: +/0/1   [???] -->
+		<!-- Control 0x4c: +/0/1   [???] -->
+		<!-- Control 0x4d: +/0/1   [???] -->
+		<!-- Control 0x4e: +/0/1   [???] -->
+		<!-- Control 0x4f: +/0/1   [???] -->
+		<!-- Control 0x50: +/0/1   [???] -->
+		<!-- Control 0x51: +/0/1   [???] -->
+		<!-- Control 0x52: +/96/255 C [???] -->
+		<!-- Control 0x53: +/96/255   [???] -->
+		<!-- Control 0x54: +/96/255   [???] -->
+		<!-- Control 0x55: +/96/255   [???] -->
+		<!-- Control 0x56: +/96/255   [???] -->
+		<!-- Control 0x57: +/96/255   [???] -->
+		<!-- Control 0x58: +/96/255   [???] -->
+		<!-- Control 0x59: +/96/255   [???] -->
+		<!-- Control 0x5a: +/96/255   [???] -->
+		<!-- Control 0x5b: +/96/255   [???] -->
+		<!-- Control 0x5c: +/96/255   [???] -->
+		<!-- Control 0x5d: +/96/255   [???] -->
+		<!-- Control 0x5e: +/96/255   [???] -->
+		<!-- Control 0x5f: +/96/255   [???] -->
+		<!-- Control 0x61: +/3855/4626   [???] -->
+		<!-- Control 0x62: +/3855/4626   [???] -->
+		<!-- Control 0x63: +/3855/4626   [???] -->
+		<!-- Control 0x64: +/3855/4626   [???] -->
+		<!-- Control 0x65: +/3855/4626   [???] -->
+		<!-- Control 0x66: +/3855/4626   [???] -->
+		<!-- Control 0x67: +/3855/4626   [???] -->
+		<!-- Control 0x68: +/3855/4626   [???] -->
+		<!-- Control 0x69: +/3855/4626   [???] -->
+		<!-- Control 0x6a: +/3855/4626   [???] -->
+		<!-- Control 0x6b: +/3855/4626   [???] -->
+		<!-- Control 0x6c: +/3855/4626   [???] -->
+		<!-- Control 0x6d: +/3855/4626   [???] -->
+		<!-- Control 0x6e: +/3855/4626   [???] -->
+		<!-- Control 0x6f: +/3855/4626   [???] -->
+		<!-- Control 0x70: +/3855/4626   [???] -->
+		<!-- Control 0x71: +/3855/4626   [???] -->
+		<!-- Control 0x72: +/3855/4626   [???] -->
+		<!-- Control 0x73: +/3855/4626   [???] -->
+		<!-- Control 0x74: +/3855/4626   [???] -->
+		<!-- Control 0x75: +/3855/4626   [???] -->
+		<!-- Control 0x76: +/3855/4626   [???] -->
+		<!-- Control 0x77: +/3855/4626   [???] -->
+		<!-- Control 0x78: +/3855/4626   [???] -->
+		<!-- Control 0x79: +/3855/4626   [???] -->
+		<!-- Control 0x7a: +/3855/4626   [???] -->
+		<!-- Control 0x7b: +/3855/4626   [???] -->
+		<!-- Control 0x7c: +/3855/4626   [???] -->
+		<!-- Control 0x7d: +/3855/4626   [???] -->
+		<!-- Control 0x7e: +/3855/4626   [???] -->
+		<!-- Control 0x7f: +/3855/4626   [???] -->
+		<!-- Control 0x80: +/3855/4626   [???] -->
+		<!-- Control 0x81: +/3855/4626   [???] -->
+		<!-- Control 0x82: +/3855/4626   [???] -->
+		<!-- Control 0x83: +/3855/4626   [???] -->
+		<!-- Control 0x84: +/3855/4626   [???] -->
+		<!-- Control 0x85: +/3855/4626   [???] -->
+		<!-- Control 0x86: +/3855/4626   [???] -->
+		<!-- Control 0x87: +/3855/4626   [???] -->
+		<!-- Control 0x88: +/3855/4626   [???] -->
+		<!-- Control 0x89: +/3855/4626   [???] -->
+		<!-- Control 0x8a: +/3855/4626   [???] -->
+		<!-- Control 0x8b: +/3855/4626   [???] -->
+		<!-- Control 0x8c: +/3855/4626   [???] -->
+		<!-- Control 0x8d: +/3855/4626   [???] -->
+		<!-- Control 0x8e: +/3855/4626   [???] -->
+		<!-- Control 0x8f: +/3855/4626   [???] -->
+		<!-- Control 0x90: +/3855/4626   [???] -->
+		<!-- Control 0x91: +/3855/4626   [???] -->
+		<!-- Control 0x92: +/3855/4626   [???] -->
+		<!-- Control 0x93: +/3855/4626   [???] -->
+		<!-- Control 0x94: +/3855/4626   [???] -->
+		<!-- Control 0x95: +/3855/4626   [???] -->
+		<!-- Control 0x96: +/3855/4626   [???] -->
+		<!-- Control 0x97: +/3855/4626   [???] -->
+		<!-- Control 0x98: +/3855/4626   [???] -->
+		<!-- Control 0x99: +/3855/4626   [???] -->
+		<!-- Control 0x9a: +/3855/4626   [???] -->
+		<!-- Control 0x9b: +/3855/4626   [???] -->
+		<!-- Control 0x9c: +/3855/4626   [???] -->
+		<!-- Control 0x9d: +/3855/4626   [???] -->
+		<!-- Control 0x9e: +/3855/4626   [???] -->
+		<!-- Control 0x9f: +/3855/4626   [???] -->
+		<!-- Control 0xa0: +/3855/4626   [???] -->
+		<!-- Control 0xa1: +/3855/4626   [???] -->
+		<!-- Control 0xa2: +/3855/4626   [???] -->
+		<!-- Control 0xa3: +/3855/4626   [???] -->
+		<!-- Control 0xa4: +/3855/4626   [???] -->
+		<!-- Control 0xa5: +/3855/4626   [???] -->
+		<!-- Control 0xa6: +/3855/4626   [???] -->
+		<!-- Control 0xa7: +/3855/4626   [???] -->
+		<!-- Control 0xa8: +/3855/4626   [???] -->
+		<!-- Control 0xa9: +/3855/4626   [???] -->
+		<!-- Control 0xab: +/1/4   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xad: +/23364/1   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/6357/65535   [???] -->
+		<!-- Control 0xc1: +/6357/65535   [???] -->
+		<!-- Control 0xc2: +/6357/65535   [???] -->
+		<!-- Control 0xc3: +/6357/65535   [???] -->
+		<!-- Control 0xc4: +/6357/65535   [???] -->
+		<!-- Control 0xc5: +/6357/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/4361/17 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcb: +/1/2   [???] -->
+		<!-- Control 0xcc: +/9/13 C [???] -->
+		<!-- Control 0xcd: +/9/13   [???] -->
+		<!-- Control 0xce: +/9/13   [???] -->
+		<!-- Control 0xcf: +/9/13   [???] -->
+		<!-- Control 0xd0: +/9/13   [???] -->
+		<!-- Control 0xd1: +/9/13   [???] -->
+		<!-- Control 0xd2: +/9/13   [???] -->
+		<!-- Control 0xd3: +/9/13   [???] -->
+		<!-- Control 0xd4: +/9/13   [???] -->
+		<!-- Control 0xd5: +/9/13   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/29/255 C [???] -->
+		<!-- Control 0xe3: +/29/255   [???] -->
+		<!-- Control 0xe4: +/29/255   [???] -->
+		<!-- Control 0xe5: +/29/255   [???] -->
+		<!-- Control 0xe6: +/29/255   [???] -->
+		<!-- Control 0xe7: +/29/255   [???] -->
+		<!-- Control 0xe8: +/29/255   [???] -->
+		<!-- Control 0xe9: +/29/255   [???] -->
+		<!-- Control 0xea: +/29/255   [???] -->
+		<!-- Control 0xeb: +/29/255   [???] -->
+		<!-- Control 0xec: +/29/255   [???] -->
+		<!-- Control 0xed: +/29/255   [???] -->
+		<!-- Control 0xee: +/29/255   [???] -->
+		<!-- Control 0xef: +/29/255   [???] -->
+		<!-- Control 0xf0: +/12/255 C [???] -->
+		<!-- Control 0xf1: +/11/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf3: +/0/255   [???] -->
+		<!-- Control 0xf4: +/0/255   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf6: +/0/255   [???] -->
+		<!-- Control 0xf7: +/0/255   [???] -->
+		<!-- Control 0xf8: +/0/255   [???] -->
+		<!-- Control 0xf9: +/0/255   [???] -->
+		<!-- Control 0xfa: +/0/255   [???] -->
+		<!-- Control 0xfb: +/0/255   [???] -->
+		<!-- Control 0xfc: +/0/255   [???] -->
+		<!-- Control 0xfd: +/99/255 C [???] -->
+		<!-- Control 0xff: +/99/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELD0C2.xml
+++ b/db/monitor/DELD0C2.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/148 -->
+<monitor name="Dell P2418D" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/53/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/98/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/94/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/99/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/0/255 C [New Control Value] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4369/4626 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/4 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/30309/29535   [???] -->
+		<!-- Control 0x01: +/30309/29535   [???] -->
+		<!-- Control 0x03: +/0/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/0/1   [???] -->
+		<!-- Control 0x0c: +/0/1   [???] -->
+		<!-- Control 0x0d: +/0/1   [???] -->
+		<!-- Control 0x0e: +/0/1   [???] -->
+		<!-- Control 0x0f: +/0/1   [???] -->
+		<!-- Control 0x11: +/53/100   [???] -->
+		<!-- Control 0x13: +/70/100   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x15: +/12/12   [???] -->
+		<!-- Control 0x17: +/98/100   [???] -->
+		<!-- Control 0x19: +/94/100   [???] -->
+		<!-- Control 0x1b: +/99/100   [???] -->
+		<!-- Control 0x1c: +/99/100   [???] -->
+		<!-- Control 0x1d: +/99/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x21: +/0/1   [???] -->
+		<!-- Control 0x22: +/0/1   [???] -->
+		<!-- Control 0x23: +/0/1   [???] -->
+		<!-- Control 0x24: +/0/1   [???] -->
+		<!-- Control 0x25: +/0/1   [???] -->
+		<!-- Control 0x26: +/0/1   [???] -->
+		<!-- Control 0x27: +/0/1   [???] -->
+		<!-- Control 0x28: +/0/1   [???] -->
+		<!-- Control 0x29: +/0/1   [???] -->
+		<!-- Control 0x2a: +/0/1   [???] -->
+		<!-- Control 0x2b: +/0/1   [???] -->
+		<!-- Control 0x2c: +/0/1   [???] -->
+		<!-- Control 0x2d: +/0/1   [???] -->
+		<!-- Control 0x2e: +/0/1   [???] -->
+		<!-- Control 0x2f: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x31: +/0/1   [???] -->
+		<!-- Control 0x32: +/0/1   [???] -->
+		<!-- Control 0x33: +/0/1   [???] -->
+		<!-- Control 0x34: +/0/1   [???] -->
+		<!-- Control 0x35: +/0/1   [???] -->
+		<!-- Control 0x36: +/0/1   [???] -->
+		<!-- Control 0x37: +/0/1   [???] -->
+		<!-- Control 0x38: +/0/1   [???] -->
+		<!-- Control 0x39: +/0/1   [???] -->
+		<!-- Control 0x3a: +/0/1   [???] -->
+		<!-- Control 0x3b: +/0/1   [???] -->
+		<!-- Control 0x3c: +/0/1   [???] -->
+		<!-- Control 0x3d: +/0/1   [???] -->
+		<!-- Control 0x3e: +/0/1   [???] -->
+		<!-- Control 0x3f: +/0/1   [???] -->
+		<!-- Control 0x40: +/0/1   [???] -->
+		<!-- Control 0x41: +/0/1   [???] -->
+		<!-- Control 0x42: +/0/1   [???] -->
+		<!-- Control 0x43: +/0/1   [???] -->
+		<!-- Control 0x44: +/0/1   [???] -->
+		<!-- Control 0x45: +/0/1   [???] -->
+		<!-- Control 0x46: +/0/1   [???] -->
+		<!-- Control 0x47: +/0/1   [???] -->
+		<!-- Control 0x48: +/0/1   [???] -->
+		<!-- Control 0x49: +/0/1   [???] -->
+		<!-- Control 0x4a: +/0/1   [???] -->
+		<!-- Control 0x4b: +/0/1   [???] -->
+		<!-- Control 0x4c: +/0/1   [???] -->
+		<!-- Control 0x4d: +/0/1   [???] -->
+		<!-- Control 0x4e: +/0/1   [???] -->
+		<!-- Control 0x4f: +/0/1   [???] -->
+		<!-- Control 0x50: +/0/1   [???] -->
+		<!-- Control 0x51: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x53: +/0/255   [???] -->
+		<!-- Control 0x54: +/0/255   [???] -->
+		<!-- Control 0x55: +/0/255   [???] -->
+		<!-- Control 0x56: +/0/255   [???] -->
+		<!-- Control 0x57: +/0/255   [???] -->
+		<!-- Control 0x58: +/0/255   [???] -->
+		<!-- Control 0x59: +/0/255   [???] -->
+		<!-- Control 0x5a: +/0/255   [???] -->
+		<!-- Control 0x5b: +/0/255   [???] -->
+		<!-- Control 0x5c: +/0/255   [???] -->
+		<!-- Control 0x5d: +/0/255   [???] -->
+		<!-- Control 0x5e: +/0/255   [???] -->
+		<!-- Control 0x5f: +/0/255   [???] -->
+		<!-- Control 0x61: +/4369/4626   [???] -->
+		<!-- Control 0x62: +/4369/4626   [???] -->
+		<!-- Control 0x63: +/4369/4626   [???] -->
+		<!-- Control 0x64: +/4369/4626   [???] -->
+		<!-- Control 0x65: +/4369/4626   [???] -->
+		<!-- Control 0x66: +/4369/4626   [???] -->
+		<!-- Control 0x67: +/4369/4626   [???] -->
+		<!-- Control 0x68: +/4369/4626   [???] -->
+		<!-- Control 0x69: +/4369/4626   [???] -->
+		<!-- Control 0x6a: +/4369/4626   [???] -->
+		<!-- Control 0x6b: +/4369/4626   [???] -->
+		<!-- Control 0x6c: +/4369/4626   [???] -->
+		<!-- Control 0x6d: +/4369/4626   [???] -->
+		<!-- Control 0x6e: +/4369/4626   [???] -->
+		<!-- Control 0x6f: +/4369/4626   [???] -->
+		<!-- Control 0x70: +/4369/4626   [???] -->
+		<!-- Control 0x71: +/4369/4626   [???] -->
+		<!-- Control 0x72: +/4369/4626   [???] -->
+		<!-- Control 0x73: +/4369/4626   [???] -->
+		<!-- Control 0x74: +/4369/4626   [???] -->
+		<!-- Control 0x75: +/4369/4626   [???] -->
+		<!-- Control 0x76: +/4369/4626   [???] -->
+		<!-- Control 0x77: +/4369/4626   [???] -->
+		<!-- Control 0x78: +/4369/4626   [???] -->
+		<!-- Control 0x79: +/4369/4626   [???] -->
+		<!-- Control 0x7a: +/4369/4626   [???] -->
+		<!-- Control 0x7b: +/4369/4626   [???] -->
+		<!-- Control 0x7c: +/4369/4626   [???] -->
+		<!-- Control 0x7d: +/4369/4626   [???] -->
+		<!-- Control 0x7e: +/4369/4626   [???] -->
+		<!-- Control 0x7f: +/4369/4626   [???] -->
+		<!-- Control 0x80: +/4369/4626   [???] -->
+		<!-- Control 0x81: +/4369/4626   [???] -->
+		<!-- Control 0x82: +/4369/4626   [???] -->
+		<!-- Control 0x83: +/4369/4626   [???] -->
+		<!-- Control 0x84: +/4369/4626   [???] -->
+		<!-- Control 0x85: +/4369/4626   [???] -->
+		<!-- Control 0x86: +/4369/4626   [???] -->
+		<!-- Control 0x87: +/4369/4626   [???] -->
+		<!-- Control 0x88: +/4369/4626   [???] -->
+		<!-- Control 0x89: +/4369/4626   [???] -->
+		<!-- Control 0x8a: +/4369/4626   [???] -->
+		<!-- Control 0x8b: +/4369/4626   [???] -->
+		<!-- Control 0x8c: +/4369/4626   [???] -->
+		<!-- Control 0x8d: +/4369/4626   [???] -->
+		<!-- Control 0x8e: +/4369/4626   [???] -->
+		<!-- Control 0x8f: +/4369/4626   [???] -->
+		<!-- Control 0x90: +/4369/4626   [???] -->
+		<!-- Control 0x91: +/4369/4626   [???] -->
+		<!-- Control 0x92: +/4369/4626   [???] -->
+		<!-- Control 0x93: +/4369/4626   [???] -->
+		<!-- Control 0x94: +/4369/4626   [???] -->
+		<!-- Control 0x95: +/4369/4626   [???] -->
+		<!-- Control 0x96: +/4369/4626   [???] -->
+		<!-- Control 0x97: +/4369/4626   [???] -->
+		<!-- Control 0x98: +/4369/4626   [???] -->
+		<!-- Control 0x99: +/4369/4626   [???] -->
+		<!-- Control 0x9a: +/4369/4626   [???] -->
+		<!-- Control 0x9b: +/4369/4626   [???] -->
+		<!-- Control 0x9c: +/4369/4626   [???] -->
+		<!-- Control 0x9d: +/4369/4626   [???] -->
+		<!-- Control 0x9e: +/4369/4626   [???] -->
+		<!-- Control 0x9f: +/4369/4626   [???] -->
+		<!-- Control 0xa0: +/4369/4626   [???] -->
+		<!-- Control 0xa1: +/4369/4626   [???] -->
+		<!-- Control 0xa2: +/4369/4626   [???] -->
+		<!-- Control 0xa3: +/4369/4626   [???] -->
+		<!-- Control 0xa4: +/4369/4626   [???] -->
+		<!-- Control 0xa5: +/4369/4626   [???] -->
+		<!-- Control 0xa6: +/4369/4626   [???] -->
+		<!-- Control 0xa7: +/4369/4626   [???] -->
+		<!-- Control 0xa8: +/4369/4626   [???] -->
+		<!-- Control 0xa9: +/4369/4626   [???] -->
+		<!-- Control 0xab: +/1/4   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xad: +/23364/1   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/3893/65535   [???] -->
+		<!-- Control 0xc1: +/3893/65535   [???] -->
+		<!-- Control 0xc2: +/3893/65535   [???] -->
+		<!-- Control 0xc3: +/3893/65535   [???] -->
+		<!-- Control 0xc4: +/3893/65535   [???] -->
+		<!-- Control 0xc5: +/3893/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/4361/17 C [???] -->
+		<!-- Control 0xc9: +/259/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcb: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xcd: +/2/13   [???] -->
+		<!-- Control 0xce: +/2/13   [???] -->
+		<!-- Control 0xcf: +/2/13   [???] -->
+		<!-- Control 0xd0: +/2/13   [???] -->
+		<!-- Control 0xd1: +/2/13   [???] -->
+		<!-- Control 0xd2: +/2/13   [???] -->
+		<!-- Control 0xd3: +/2/13   [???] -->
+		<!-- Control 0xd4: +/2/13   [???] -->
+		<!-- Control 0xd5: +/2/13   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/0/5 C [???] -->
+		<!-- Control 0xdd: +/0/5   [???] -->
+		<!-- Control 0xde: +/0/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/255 C [???] -->
+		<!-- Control 0xe3: +/20/255   [???] -->
+		<!-- Control 0xe4: +/20/255   [???] -->
+		<!-- Control 0xe5: +/20/255   [???] -->
+		<!-- Control 0xe6: +/20/255   [???] -->
+		<!-- Control 0xe7: +/20/255   [???] -->
+		<!-- Control 0xe8: +/20/255   [???] -->
+		<!-- Control 0xe9: +/20/255   [???] -->
+		<!-- Control 0xea: +/20/255   [???] -->
+		<!-- Control 0xeb: +/20/255   [???] -->
+		<!-- Control 0xec: +/20/255   [???] -->
+		<!-- Control 0xed: +/20/255   [???] -->
+		<!-- Control 0xee: +/20/255   [???] -->
+		<!-- Control 0xef: +/20/255   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf3: +/0/255   [???] -->
+		<!-- Control 0xf4: +/0/255   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf6: +/0/255   [???] -->
+		<!-- Control 0xf7: +/0/255   [???] -->
+		<!-- Control 0xf8: +/0/255   [???] -->
+		<!-- Control 0xf9: +/0/255   [???] -->
+		<!-- Control 0xfa: +/0/255   [???] -->
+		<!-- Control 0xfb: +/0/255   [???] -->
+		<!-- Control 0xfc: +/0/255   [???] -->
+		<!-- Control 0xfd: +/99/255 C [???] -->
+		<!-- Control 0xff: +/99/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELD0D9.xml
+++ b/db/monitor/DELD0D9.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/199 -->
+<monitor name="Dell P2419H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/75/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/75/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/75/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3855/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/249/100   [???] -->
+		<!-- Control 0x30: +/11/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x62: +/0/255   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x8d: +/0/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/10768/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/10497/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/29/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/12/255 C [???] -->
+		<!-- Control 0xf1: +/11/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/1/1   [???] -->
+		<!-- Control 0xfc: +/18/255   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELD0FF.xml
+++ b/db/monitor/DELD0FF.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/171 -->
+<monitor name="Dell P2421D" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/81/100 C [Brightness] -->
+		<!-- Control 0x12: +/72/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4369/27 C [Input Source Select] -->
+		<!-- Control 0xaa: +/2/255 C [OSD Orientation - Portrait] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/154/100   [???] -->
+		<!-- Control 0x30: +/34/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x62: +/0/255   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x8d: +/0/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/118/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/10500/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/99/65535 C [???] -->
+		<!-- Control 0xfe: +/99/291   [???] -->
+		<!-- Control 0xff: +/99/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELF011.xml
+++ b/db/monitor/DELF011.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/18 -->
+<monitor name="Dell 2209WAf" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/39/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/96/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/92/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/255 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/14 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/0/24028 [???] -->
+		<!-- Control 0x0c: +/2/255 [???] -->
+		<!-- Control 0x0e: +/50/100 [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x1e: +/0/2 [???] -->
+		<!-- Control 0x20: +/219/100 [???] -->
+		<!-- Control 0x30: +/29/100 [???] -->
+		<!-- Control 0x3e: +/87/100 [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x68: +/0/5 [???] -->
+		<!-- Control 0x6c: +/128/255 [???] -->
+		<!-- Control 0x6e: +/128/255 [???] -->
+		<!-- Control 0x70: +/128/255 [???] -->
+		<!-- Control 0xa8: +/0/3 [???] -->
+		<!-- Control 0xac: +/65200/0 C [???] -->
+		<!-- Control 0xae: +/5990/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2 [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/0/65535 [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/264/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe3: +/0/1 [???] -->
+		<!-- Control 0xfa: +/0/65535 [???] -->
+		<!-- Control 0xfd: +/102/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535 [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/DELF10E.xml
+++ b/db/monitor/DELF10E.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/149 -->
+<monitor name="Dell SE2219HX" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/10/100 C [Brightness] -->
+		<!-- Control 0x12: +/77/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/2 C [Automatically adjust] -->
+		<!-- Control 0x20: +/20/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/29/100 C [Image Lock Fine (Clock Phase)] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/255 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/257/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x14: +/12/12 C [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x62: +/0/255   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x8d: +/0/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/1664/1 C [???] -->
+		<!-- Control 0xae: +/5970/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/4762/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/10497/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/14 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/20/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/11/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/102/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/ENC2214.xml
+++ b/db/monitor/ENC2214.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/11 -->
+<monitor name="EIZO Foris FS2331" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps remove="(vcp(00 02 04 05 06 08 0E 10 12 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- No controls were explicitly named by the issue scan. -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GBT2706.xml
+++ b/db/monitor/GBT2706.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/307 -->
+<monitor name="Gigabyte Aorus FI27Q" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/18/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/70/170 C [???] -->
+		<!-- Control 0x14: +/7/11 C [???] -->
+		<!-- Control 0x52: +/0/255   [???] -->
+		<!-- Control 0x87: +/5/10   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/23264/65281 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xc0: +/133/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/255 C [???] -->
+		<!-- Control 0xdc: +/2/10   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/513/65535   [???] -->
+		<!-- Control 0xec: +/1/1   [???] -->
+		<!-- Control 0xfe: +/0/255   [???] -->
+		<!-- Control 0xff: +/0/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5678.xml
+++ b/db/monitor/GSM5678.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/105 -->
+<monitor name="LG Flatron W2242PM (GSM5678)" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/73/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/65535 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select (Main) - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xfd: +/1/1 C [Power LED - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/65535 C [???] -->
+		<!-- Control 0x06: +/0/65535   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/100/5000 C [???] -->
+		<!-- Control 0x0c: +/35/100 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/224/448   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x15: +/0/0   [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/65535   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/220/440   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/34/68   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/32/63   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/0/0   [???] -->
+		<!-- Control 0x4e: +/0/0   [???] -->
+		<!-- Control 0x4f: +/0/0   [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/0/0 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x62: +/0/0   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/5/10 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/0/0   [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/65200/0 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/5980/0 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/0/0   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/12888/65535 C [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/5/65535 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/0/0   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/0/0   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/0   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/0   [???] -->
+		<!-- Control 0xe1: +/0/0   [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/0   [???] -->
+		<!-- Control 0xe4: +/0/0   [???] -->
+		<!-- Control 0xe5: +/0/0   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/0   [???] -->
+		<!-- Control 0xec: +/0/0   [???] -->
+		<!-- Control 0xed: +/0/0   [???] -->
+		<!-- Control 0xee: +/0/0   [???] -->
+		<!-- Control 0xef: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/100/100 C [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/0/3 C [???] -->
+		<!-- Control 0xf4: +/0/0   [???] -->
+		<!-- Control 0xf5: +/0/0   [???] -->
+		<!-- Control 0xf6: +/0/0   [???] -->
+		<!-- Control 0xf7: +/0/0   [???] -->
+		<!-- Control 0xf8: +/0/0   [???] -->
+		<!-- Control 0xf9: +/0/0   [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/0/3 C [???] -->
+		<!-- Control 0xfe: +/1/2 C [???] -->
+		<!-- Control 0xff: +/0/0 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM580C.xml
+++ b/db/monitor/GSM580C.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/15 -->
+<monitor name="LG Flatron IPS236" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/58/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/65535 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/65535 C [???] -->
+		<!-- Control 0x06: +/0/65535   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/100/5000 C [???] -->
+		<!-- Control 0x0c: +/55/100 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/70/140   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/7/11 C [???] -->
+		<!-- Control 0x15: +/0/0   [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/65535   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/55/100   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/35/67   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/0/63   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/0/0   [???] -->
+		<!-- Control 0x4e: +/0/0   [???] -->
+		<!-- Control 0x4f: +/0/0   [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/16/0 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x62: +/0/0   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/10/10 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/0/0   [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/0/0   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/9473/65535   [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/37/65535 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/0/0   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/0/0   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/0   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe2: +/0/65535 C [???] -->
+		<!-- Control 0xe3: +/0/0   [???] -->
+		<!-- Control 0xe4: +/0/0   [???] -->
+		<!-- Control 0xe5: +/0/0   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/0   [???] -->
+		<!-- Control 0xec: +/0/0   [???] -->
+		<!-- Control 0xed: +/0/0   [???] -->
+		<!-- Control 0xee: +/0/0   [???] -->
+		<!-- Control 0xef: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/0/0   [???] -->
+		<!-- Control 0xf2: +/0/0   [???] -->
+		<!-- Control 0xf3: +/0/0   [???] -->
+		<!-- Control 0xf4: +/0/0   [???] -->
+		<!-- Control 0xf5: +/0/0   [???] -->
+		<!-- Control 0xf6: +/0/0   [???] -->
+		<!-- Control 0xf7: +/0/0   [???] -->
+		<!-- Control 0xf8: +/0/0   [???] -->
+		<!-- Control 0xf9: +/0/0   [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/1/3 C [???] -->
+		<!-- Control 0xfd: +/0/1 C [???] -->
+		<!-- Control 0xfe: +/4/4 C [???] -->
+		<!-- Control 0xff: +/0/0 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5A20.xml
+++ b/db/monitor/GSM5A20.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/63 -->
+<monitor name="LG 24MP55HQ" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/10/100 C [Brightness] -->
+		<!-- Control 0x12: +/59/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/255/65535 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+		<!-- Control 0xfd: +/0/0 C [Power LED - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/1/65535 C [???] -->
+		<!-- Control 0x06: +/0/65535   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/100/5000 C [???] -->
+		<!-- Control 0x0c: +/35/100 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/112/224   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x15: +/0/0   [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/65535   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/0/0   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/65535/65534   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/0/63   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/0/0   [???] -->
+		<!-- Control 0x4e: +/0/0   [???] -->
+		<!-- Control 0x4f: +/0/0   [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/0/0 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x62: +/0/0   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/5/10 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/0/0   [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/1864/1 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/0/0   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/12001/65535 C [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/0/0   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/0/65535   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/0   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/1/65535 C [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/65535 C [???] -->
+		<!-- Control 0xe4: +/0/0   [???] -->
+		<!-- Control 0xe5: +/0/0   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/0   [???] -->
+		<!-- Control 0xec: +/0/65535 C [???] -->
+		<!-- Control 0xed: +/0/0   [???] -->
+		<!-- Control 0xee: +/0/0   [???] -->
+		<!-- Control 0xef: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/0/0   [???] -->
+		<!-- Control 0xf2: +/0/2   [???] -->
+		<!-- Control 0xf3: +/0/3   [???] -->
+		<!-- Control 0xf4: +/0/0   [???] -->
+		<!-- Control 0xf5: +/0/0   [???] -->
+		<!-- Control 0xf6: +/0/0   [???] -->
+		<!-- Control 0xf7: +/0/0   [???] -->
+		<!-- Control 0xf8: +/0/0   [???] -->
+		<!-- Control 0xf9: +/0/0   [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/0/3   [???] -->
+		<!-- Control 0xfe: +/1/2 C [???] -->
+		<!-- Control 0xff: +/0/0 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5AB7.xml
+++ b/db/monitor/GSM5AB7.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/73 -->
+<monitor name="LG 24MP58VQ" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/20/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/30/255 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/255/65535 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/65535 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/65535 C [???] -->
+		<!-- Control 0x06: +/0/65535   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/100/5000 C [???] -->
+		<!-- Control 0x0c: +/35/100 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/262/524   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x15: +/11/255 C [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/65535   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/0/0   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/65535/65534   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/0/63   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/125/65535 C [???] -->
+		<!-- Control 0x4e: +/16384/65535 C [???] -->
+		<!-- Control 0x4f: +/0/65535 C [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/0/0 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/2/0 C [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/1864/1 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/0/0   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/559/65535 C [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/770/65535 C [???] -->
+		<!-- Control 0xca: +/0/0   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/0/65535   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/0   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/1/65535 C [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/65535 C [???] -->
+		<!-- Control 0xe4: +/0/0   [???] -->
+		<!-- Control 0xe5: +/0/0   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/0   [???] -->
+		<!-- Control 0xec: +/0/65535 C [???] -->
+		<!-- Control 0xed: +/0/0   [???] -->
+		<!-- Control 0xee: +/0/0   [???] -->
+		<!-- Control 0xef: +/0/0 C [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/0/0   [???] -->
+		<!-- Control 0xf2: +/0/2   [???] -->
+		<!-- Control 0xf3: +/0/3   [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/0/255 C [???] -->
+		<!-- Control 0xf7: +/1/255 C [???] -->
+		<!-- Control 0xf8: +/255/0 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/0/3   [???] -->
+		<!-- Control 0xfd: +/0/0   [???] -->
+		<!-- Control 0xfe: +/1/2   [???] -->
+		<!-- Control 0xff: +/0/0 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5AB8.xml
+++ b/db/monitor/GSM5AB8.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/262 -->
+<monitor name="LG 22MP68VQ-P" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/60/100 C [Brightness] -->
+		<!-- Control 0x12: +/60/100 C [Contrast] -->
+		<!-- Control 0x16: +/55/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/65/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/128/178 C [Red minimum level] -->
+		<!-- Control 0x6e: +/128/178 C [Green minimum level] -->
+		<!-- Control 0x70: +/128/178 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/255/65535 C [New Control Value] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xfd: +/0/1 C [Power LED - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/65535 C [???] -->
+		<!-- Control 0x06: +/0/65535   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/100/5000 C [???] -->
+		<!-- Control 0x0c: +/35/100 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/90/180   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x15: +/11/255   [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/65535   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/109/218   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/43/86   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/0/63   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/125/65535   [???] -->
+		<!-- Control 0x4e: +/16384/65535   [???] -->
+		<!-- Control 0x4f: +/0/65535   [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/0/0 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x62: +/30/255   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/2/10 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/2/0   [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/6010/0 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/0/0   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/2847/65535 C [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/5/65535 C [???] -->
+		<!-- Control 0xc9: +/768/65535 C [???] -->
+		<!-- Control 0xca: +/0/0   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/0/0   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/0   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/65535 C [???] -->
+		<!-- Control 0xe1: +/0/0   [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/0   [???] -->
+		<!-- Control 0xe4: +/0/0   [???] -->
+		<!-- Control 0xe5: +/0/0   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe8: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/0   [???] -->
+		<!-- Control 0xea: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/0   [???] -->
+		<!-- Control 0xec: +/0/65535   [???] -->
+		<!-- Control 0xed: +/0/0   [???] -->
+		<!-- Control 0xee: +/0/0   [???] -->
+		<!-- Control 0xef: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/0/0   [???] -->
+		<!-- Control 0xf2: +/0/2   [???] -->
+		<!-- Control 0xf3: +/0/3   [???] -->
+		<!-- Control 0xf4: +/6/65535   [???] -->
+		<!-- Control 0xf5: +/2/255   [???] -->
+		<!-- Control 0xf6: +/0/2   [???] -->
+		<!-- Control 0xf7: +/1/255   [???] -->
+		<!-- Control 0xf8: +/0/255   [???] -->
+		<!-- Control 0xf9: +/50/255   [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/0/3   [???] -->
+		<!-- Control 0xfe: +/1/2 C [???] -->
+		<!-- Control 0xff: +/0/0 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5AE2.xml
+++ b/db/monitor/GSM5AE2.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/44 -->
+<monitor name="LG 34UC88-B" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/20/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/14/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/0/18 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xfd: +/0/65535 C [Power LED - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/65535   [???] -->
+		<!-- Control 0x01: +/0/65535   [???] -->
+		<!-- Control 0x03: +/0/65535   [???] -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x07: +/0/65535   [???] -->
+		<!-- Control 0x09: +/0/65535   [???] -->
+		<!-- Control 0x0a: +/0/65535   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0d: +/0/65535   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/0/65535   [???] -->
+		<!-- Control 0x11: +/0/65535   [???] -->
+		<!-- Control 0x13: +/0/65535   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x15: +/11/255 C [???] -->
+		<!-- Control 0x17: +/0/65535   [???] -->
+		<!-- Control 0x19: +/0/65535   [???] -->
+		<!-- Control 0x1b: +/0/65535   [???] -->
+		<!-- Control 0x1c: +/0/65535   [???] -->
+		<!-- Control 0x1d: +/0/65535   [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x1f: +/0/65535   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x21: +/0/65535   [???] -->
+		<!-- Control 0x22: +/0/65535   [???] -->
+		<!-- Control 0x23: +/0/65535   [???] -->
+		<!-- Control 0x24: +/0/65535   [???] -->
+		<!-- Control 0x25: +/0/65535   [???] -->
+		<!-- Control 0x26: +/0/65535   [???] -->
+		<!-- Control 0x27: +/0/65535   [???] -->
+		<!-- Control 0x28: +/0/65535   [???] -->
+		<!-- Control 0x29: +/0/65535   [???] -->
+		<!-- Control 0x2a: +/0/65535   [???] -->
+		<!-- Control 0x2b: +/0/65535   [???] -->
+		<!-- Control 0x2c: +/0/65535   [???] -->
+		<!-- Control 0x2d: +/0/65535   [???] -->
+		<!-- Control 0x2e: +/0/65535   [???] -->
+		<!-- Control 0x2f: +/0/65535   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x31: +/0/65535   [???] -->
+		<!-- Control 0x32: +/0/65535   [???] -->
+		<!-- Control 0x33: +/0/65535   [???] -->
+		<!-- Control 0x34: +/0/65535   [???] -->
+		<!-- Control 0x35: +/0/65535   [???] -->
+		<!-- Control 0x36: +/0/65535   [???] -->
+		<!-- Control 0x37: +/0/65535   [???] -->
+		<!-- Control 0x38: +/0/65535   [???] -->
+		<!-- Control 0x39: +/0/65535   [???] -->
+		<!-- Control 0x3a: +/0/65535   [???] -->
+		<!-- Control 0x3b: +/0/65535   [???] -->
+		<!-- Control 0x3c: +/0/65535   [???] -->
+		<!-- Control 0x3d: +/0/65535   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/0/65535   [???] -->
+		<!-- Control 0x40: +/0/65535   [???] -->
+		<!-- Control 0x41: +/0/65535   [???] -->
+		<!-- Control 0x42: +/0/65535   [???] -->
+		<!-- Control 0x43: +/0/65535   [???] -->
+		<!-- Control 0x44: +/0/65535   [???] -->
+		<!-- Control 0x45: +/0/65535   [???] -->
+		<!-- Control 0x46: +/0/65535   [???] -->
+		<!-- Control 0x47: +/0/65535   [???] -->
+		<!-- Control 0x48: +/0/65535   [???] -->
+		<!-- Control 0x49: +/0/65535   [???] -->
+		<!-- Control 0x4a: +/0/65535   [???] -->
+		<!-- Control 0x4b: +/0/65535   [???] -->
+		<!-- Control 0x4c: +/0/65535   [???] -->
+		<!-- Control 0x4d: +/32307/65535 C [???] -->
+		<!-- Control 0x4e: +/16384/65535 C [???] -->
+		<!-- Control 0x4f: +/0/65535 C [???] -->
+		<!-- Control 0x50: +/0/65535   [???] -->
+		<!-- Control 0x51: +/0/65535   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x53: +/0/65535   [???] -->
+		<!-- Control 0x54: +/0/65535   [???] -->
+		<!-- Control 0x55: +/0/65535   [???] -->
+		<!-- Control 0x56: +/0/65535   [???] -->
+		<!-- Control 0x57: +/0/65535   [???] -->
+		<!-- Control 0x58: +/0/65535   [???] -->
+		<!-- Control 0x59: +/0/65535   [???] -->
+		<!-- Control 0x5a: +/0/65535   [???] -->
+		<!-- Control 0x5b: +/0/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x5d: +/0/65535   [???] -->
+		<!-- Control 0x5e: +/0/65535   [???] -->
+		<!-- Control 0x5f: +/0/65535   [???] -->
+		<!-- Control 0x61: +/0/65535   [???] -->
+		<!-- Control 0x63: +/0/65535   [???] -->
+		<!-- Control 0x64: +/0/65535   [???] -->
+		<!-- Control 0x65: +/0/65535   [???] -->
+		<!-- Control 0x66: +/0/65535   [???] -->
+		<!-- Control 0x67: +/0/65535   [???] -->
+		<!-- Control 0x68: +/0/65535   [???] -->
+		<!-- Control 0x69: +/0/65535   [???] -->
+		<!-- Control 0x6a: +/0/65535   [???] -->
+		<!-- Control 0x6b: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6d: +/0/65535   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x6f: +/0/65535   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x71: +/0/65535   [???] -->
+		<!-- Control 0x72: +/0/65535   [???] -->
+		<!-- Control 0x73: +/0/65535   [???] -->
+		<!-- Control 0x74: +/0/65535   [???] -->
+		<!-- Control 0x75: +/0/65535   [???] -->
+		<!-- Control 0x76: +/0/65535   [???] -->
+		<!-- Control 0x77: +/0/65535   [???] -->
+		<!-- Control 0x78: +/0/65535   [???] -->
+		<!-- Control 0x79: +/0/65535   [???] -->
+		<!-- Control 0x7a: +/0/65535   [???] -->
+		<!-- Control 0x7b: +/0/65535   [???] -->
+		<!-- Control 0x7c: +/0/65535   [???] -->
+		<!-- Control 0x7d: +/0/65535   [???] -->
+		<!-- Control 0x7e: +/0/65535   [???] -->
+		<!-- Control 0x7f: +/0/65535   [???] -->
+		<!-- Control 0x80: +/0/65535   [???] -->
+		<!-- Control 0x81: +/0/65535   [???] -->
+		<!-- Control 0x82: +/0/65535   [???] -->
+		<!-- Control 0x83: +/0/65535   [???] -->
+		<!-- Control 0x84: +/0/65535   [???] -->
+		<!-- Control 0x85: +/0/65535   [???] -->
+		<!-- Control 0x86: +/0/65535   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x88: +/0/65535   [???] -->
+		<!-- Control 0x89: +/0/65535   [???] -->
+		<!-- Control 0x8a: +/0/65535   [???] -->
+		<!-- Control 0x8b: +/0/65535   [???] -->
+		<!-- Control 0x8c: +/0/65535   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0x8e: +/0/65535   [???] -->
+		<!-- Control 0x8f: +/0/65535   [???] -->
+		<!-- Control 0x90: +/0/65535   [???] -->
+		<!-- Control 0x91: +/0/65535   [???] -->
+		<!-- Control 0x92: +/0/65535   [???] -->
+		<!-- Control 0x93: +/0/65535   [???] -->
+		<!-- Control 0x94: +/0/65535   [???] -->
+		<!-- Control 0x95: +/0/65535   [???] -->
+		<!-- Control 0x96: +/0/65535   [???] -->
+		<!-- Control 0x97: +/0/65535   [???] -->
+		<!-- Control 0x98: +/0/65535   [???] -->
+		<!-- Control 0x99: +/0/65535   [???] -->
+		<!-- Control 0x9a: +/0/65535   [???] -->
+		<!-- Control 0x9b: +/0/65535   [???] -->
+		<!-- Control 0x9c: +/0/65535   [???] -->
+		<!-- Control 0x9d: +/0/65535   [???] -->
+		<!-- Control 0x9e: +/0/65535   [???] -->
+		<!-- Control 0x9f: +/0/65535   [???] -->
+		<!-- Control 0xa0: +/0/65535   [???] -->
+		<!-- Control 0xa1: +/0/65535   [???] -->
+		<!-- Control 0xa2: +/0/65535   [???] -->
+		<!-- Control 0xa3: +/0/65535   [???] -->
+		<!-- Control 0xa4: +/0/65535   [???] -->
+		<!-- Control 0xa5: +/0/65535   [???] -->
+		<!-- Control 0xa6: +/0/65535   [???] -->
+		<!-- Control 0xa7: +/0/65535   [???] -->
+		<!-- Control 0xa8: +/0/65535   [???] -->
+		<!-- Control 0xa9: +/0/65535   [???] -->
+		<!-- Control 0xaa: +/0/65535   [???] -->
+		<!-- Control 0xab: +/0/65535   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xad: +/0/65535   [???] -->
+		<!-- Control 0xae: +/6003/0 C [???] -->
+		<!-- Control 0xaf: +/0/65535   [???] -->
+		<!-- Control 0xb0: +/0/65535   [???] -->
+		<!-- Control 0xb1: +/0/65535   [???] -->
+		<!-- Control 0xb2: +/0/65535 C [???] -->
+		<!-- Control 0xb3: +/0/65535   [???] -->
+		<!-- Control 0xb4: +/0/65535   [???] -->
+		<!-- Control 0xb5: +/0/65535   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/0/65535   [???] -->
+		<!-- Control 0xb8: +/0/65535   [???] -->
+		<!-- Control 0xb9: +/0/65535   [???] -->
+		<!-- Control 0xba: +/0/65535   [???] -->
+		<!-- Control 0xbb: +/0/65535   [???] -->
+		<!-- Control 0xbc: +/0/65535   [???] -->
+		<!-- Control 0xbd: +/0/65535   [???] -->
+		<!-- Control 0xbe: +/0/65535   [???] -->
+		<!-- Control 0xbf: +/0/65535   [???] -->
+		<!-- Control 0xc0: +/51/65535 C [???] -->
+		<!-- Control 0xc1: +/0/65535   [???] -->
+		<!-- Control 0xc2: +/0/65535   [???] -->
+		<!-- Control 0xc3: +/0/65535   [???] -->
+		<!-- Control 0xc4: +/0/65535   [???] -->
+		<!-- Control 0xc5: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/65535   [???] -->
+		<!-- Control 0xc8: +/5/255 C [???] -->
+		<!-- Control 0xc9: +/775/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcb: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/0/255   [???] -->
+		<!-- Control 0xcd: +/0/65535   [???] -->
+		<!-- Control 0xce: +/0/65535   [???] -->
+		<!-- Control 0xcf: +/0/65535   [???] -->
+		<!-- Control 0xd0: +/0/65535   [???] -->
+		<!-- Control 0xd1: +/0/65535   [???] -->
+		<!-- Control 0xd2: +/0/65535   [???] -->
+		<!-- Control 0xd3: +/0/65535   [???] -->
+		<!-- Control 0xd4: +/0/65535   [???] -->
+		<!-- Control 0xd5: +/0/65535   [???] -->
+		<!-- Control 0xd7: +/0/65535   [???] -->
+		<!-- Control 0xd8: +/0/65535   [???] -->
+		<!-- Control 0xd9: +/0/65535   [???] -->
+		<!-- Control 0xda: +/0/65535   [???] -->
+		<!-- Control 0xdb: +/0/65535   [???] -->
+		<!-- Control 0xdc: +/0/65535   [???] -->
+		<!-- Control 0xdd: +/0/65535   [???] -->
+		<!-- Control 0xde: +/0/65535   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/65535   [???] -->
+		<!-- Control 0xe1: +/0/65535   [???] -->
+		<!-- Control 0xe2: +/0/65535   [???] -->
+		<!-- Control 0xe3: +/0/65535   [???] -->
+		<!-- Control 0xe4: +/0/255   [???] -->
+		<!-- Control 0xe5: +/0/179   [???] -->
+		<!-- Control 0xe6: +/0/65535   [???] -->
+		<!-- Control 0xe7: +/0/65535   [???] -->
+		<!-- Control 0xe8: +/0/255   [???] -->
+		<!-- Control 0xe9: +/2/255   [???] -->
+		<!-- Control 0xea: +/0/255   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xec: +/0/65535   [???] -->
+		<!-- Control 0xed: +/0/65535   [???] -->
+		<!-- Control 0xee: +/0/65535   [???] -->
+		<!-- Control 0xef: +/1/65535   [???] -->
+		<!-- Control 0xf0: +/0/65535   [???] -->
+		<!-- Control 0xf1: +/0/65535   [???] -->
+		<!-- Control 0xf2: +/0/65535   [???] -->
+		<!-- Control 0xf3: +/0/65535   [???] -->
+		<!-- Control 0xf4: +/31/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/1/255 C [???] -->
+		<!-- Control 0xf7: +/2/255 C [???] -->
+		<!-- Control 0xf8: +/0/255 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/0/65535   [???] -->
+		<!-- Control 0xfc: +/0/65535   [???] -->
+		<!-- Control 0xfe: +/2/255 C [???] -->
+		<!-- Control 0xff: +/0/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5B00.xml
+++ b/db/monitor/GSM5B00.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/62 -->
+<monitor name="LG 27MU67-B" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/5/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/18 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xfd: +/0/65535 C [Power LED - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/65535   [???] -->
+		<!-- Control 0x01: +/0/65535   [???] -->
+		<!-- Control 0x03: +/0/65535   [???] -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x07: +/0/65535   [???] -->
+		<!-- Control 0x09: +/0/65535   [???] -->
+		<!-- Control 0x0a: +/0/65535   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0d: +/0/65535   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x0f: +/0/65535   [???] -->
+		<!-- Control 0x11: +/0/65535   [???] -->
+		<!-- Control 0x13: +/0/65535   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x15: +/0/65535   [???] -->
+		<!-- Control 0x17: +/0/65535   [???] -->
+		<!-- Control 0x19: +/0/65535   [???] -->
+		<!-- Control 0x1b: +/0/65535   [???] -->
+		<!-- Control 0x1c: +/0/65535   [???] -->
+		<!-- Control 0x1d: +/0/65535   [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x1f: +/0/65535   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x21: +/0/65535   [???] -->
+		<!-- Control 0x22: +/0/65535   [???] -->
+		<!-- Control 0x23: +/0/65535   [???] -->
+		<!-- Control 0x24: +/0/65535   [???] -->
+		<!-- Control 0x25: +/0/65535   [???] -->
+		<!-- Control 0x26: +/0/65535   [???] -->
+		<!-- Control 0x27: +/0/65535   [???] -->
+		<!-- Control 0x28: +/0/65535   [???] -->
+		<!-- Control 0x29: +/0/65535   [???] -->
+		<!-- Control 0x2a: +/0/65535   [???] -->
+		<!-- Control 0x2b: +/0/65535   [???] -->
+		<!-- Control 0x2c: +/0/65535   [???] -->
+		<!-- Control 0x2d: +/0/65535   [???] -->
+		<!-- Control 0x2e: +/0/65535   [???] -->
+		<!-- Control 0x2f: +/0/65535   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x31: +/0/65535   [???] -->
+		<!-- Control 0x32: +/0/65535   [???] -->
+		<!-- Control 0x33: +/0/65535   [???] -->
+		<!-- Control 0x34: +/0/65535   [???] -->
+		<!-- Control 0x35: +/0/65535   [???] -->
+		<!-- Control 0x36: +/0/65535   [???] -->
+		<!-- Control 0x37: +/0/65535   [???] -->
+		<!-- Control 0x38: +/0/65535   [???] -->
+		<!-- Control 0x39: +/0/65535   [???] -->
+		<!-- Control 0x3a: +/0/65535   [???] -->
+		<!-- Control 0x3b: +/0/65535   [???] -->
+		<!-- Control 0x3c: +/0/65535   [???] -->
+		<!-- Control 0x3d: +/0/65535   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x3f: +/0/65535   [???] -->
+		<!-- Control 0x40: +/0/65535   [???] -->
+		<!-- Control 0x41: +/0/65535   [???] -->
+		<!-- Control 0x42: +/0/65535   [???] -->
+		<!-- Control 0x43: +/0/65535   [???] -->
+		<!-- Control 0x44: +/0/65535   [???] -->
+		<!-- Control 0x45: +/0/65535   [???] -->
+		<!-- Control 0x46: +/0/65535   [???] -->
+		<!-- Control 0x47: +/0/65535   [???] -->
+		<!-- Control 0x48: +/0/65535   [???] -->
+		<!-- Control 0x49: +/0/65535   [???] -->
+		<!-- Control 0x4a: +/0/65535   [???] -->
+		<!-- Control 0x4b: +/0/65535   [???] -->
+		<!-- Control 0x4c: +/0/65535   [???] -->
+		<!-- Control 0x4d: +/0/65535   [???] -->
+		<!-- Control 0x4e: +/0/65535   [???] -->
+		<!-- Control 0x4f: +/0/65535   [???] -->
+		<!-- Control 0x50: +/0/65535   [???] -->
+		<!-- Control 0x51: +/0/65535   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x53: +/0/65535   [???] -->
+		<!-- Control 0x54: +/0/65535   [???] -->
+		<!-- Control 0x55: +/0/65535   [???] -->
+		<!-- Control 0x56: +/0/65535   [???] -->
+		<!-- Control 0x57: +/0/65535   [???] -->
+		<!-- Control 0x58: +/0/65535   [???] -->
+		<!-- Control 0x59: +/0/65535   [???] -->
+		<!-- Control 0x5a: +/0/65535   [???] -->
+		<!-- Control 0x5b: +/0/65535   [???] -->
+		<!-- Control 0x5c: +/0/65535   [???] -->
+		<!-- Control 0x5d: +/0/65535   [???] -->
+		<!-- Control 0x5e: +/0/65535   [???] -->
+		<!-- Control 0x5f: +/0/65535   [???] -->
+		<!-- Control 0x61: +/0/65535   [???] -->
+		<!-- Control 0x62: +/0/65535   [???] -->
+		<!-- Control 0x63: +/0/65535   [???] -->
+		<!-- Control 0x64: +/0/65535   [???] -->
+		<!-- Control 0x65: +/0/65535   [???] -->
+		<!-- Control 0x66: +/0/65535   [???] -->
+		<!-- Control 0x67: +/0/65535   [???] -->
+		<!-- Control 0x68: +/0/65535   [???] -->
+		<!-- Control 0x69: +/0/65535   [???] -->
+		<!-- Control 0x6a: +/0/65535   [???] -->
+		<!-- Control 0x6b: +/0/65535   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6d: +/0/65535   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x6f: +/0/65535   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x71: +/0/65535   [???] -->
+		<!-- Control 0x72: +/0/65535   [???] -->
+		<!-- Control 0x73: +/0/65535   [???] -->
+		<!-- Control 0x74: +/0/65535   [???] -->
+		<!-- Control 0x75: +/0/65535   [???] -->
+		<!-- Control 0x76: +/0/65535   [???] -->
+		<!-- Control 0x77: +/0/65535   [???] -->
+		<!-- Control 0x78: +/0/65535   [???] -->
+		<!-- Control 0x79: +/0/65535   [???] -->
+		<!-- Control 0x7a: +/0/65535   [???] -->
+		<!-- Control 0x7b: +/0/65535   [???] -->
+		<!-- Control 0x7c: +/0/65535   [???] -->
+		<!-- Control 0x7d: +/0/65535   [???] -->
+		<!-- Control 0x7e: +/0/65535   [???] -->
+		<!-- Control 0x7f: +/0/65535   [???] -->
+		<!-- Control 0x80: +/0/65535   [???] -->
+		<!-- Control 0x81: +/0/65535   [???] -->
+		<!-- Control 0x82: +/0/65535   [???] -->
+		<!-- Control 0x83: +/0/65535   [???] -->
+		<!-- Control 0x84: +/0/65535   [???] -->
+		<!-- Control 0x85: +/0/65535   [???] -->
+		<!-- Control 0x86: +/0/65535   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x88: +/0/65535   [???] -->
+		<!-- Control 0x89: +/0/65535   [???] -->
+		<!-- Control 0x8a: +/0/65535   [???] -->
+		<!-- Control 0x8b: +/0/65535   [???] -->
+		<!-- Control 0x8c: +/0/65535   [???] -->
+		<!-- Control 0x8d: +/0/65535   [???] -->
+		<!-- Control 0x8e: +/0/65535   [???] -->
+		<!-- Control 0x8f: +/0/65535   [???] -->
+		<!-- Control 0x90: +/0/65535   [???] -->
+		<!-- Control 0x91: +/0/65535   [???] -->
+		<!-- Control 0x92: +/0/65535   [???] -->
+		<!-- Control 0x93: +/0/65535   [???] -->
+		<!-- Control 0x94: +/0/65535   [???] -->
+		<!-- Control 0x95: +/0/65535   [???] -->
+		<!-- Control 0x96: +/0/65535   [???] -->
+		<!-- Control 0x97: +/0/65535   [???] -->
+		<!-- Control 0x98: +/0/65535   [???] -->
+		<!-- Control 0x99: +/0/65535   [???] -->
+		<!-- Control 0x9a: +/0/65535   [???] -->
+		<!-- Control 0x9b: +/0/65535   [???] -->
+		<!-- Control 0x9c: +/0/65535   [???] -->
+		<!-- Control 0x9d: +/0/65535   [???] -->
+		<!-- Control 0x9e: +/0/65535   [???] -->
+		<!-- Control 0x9f: +/0/65535   [???] -->
+		<!-- Control 0xa0: +/0/65535   [???] -->
+		<!-- Control 0xa1: +/0/65535   [???] -->
+		<!-- Control 0xa2: +/0/65535   [???] -->
+		<!-- Control 0xa3: +/0/65535   [???] -->
+		<!-- Control 0xa4: +/0/65535   [???] -->
+		<!-- Control 0xa5: +/0/65535   [???] -->
+		<!-- Control 0xa6: +/0/65535   [???] -->
+		<!-- Control 0xa7: +/0/65535   [???] -->
+		<!-- Control 0xa8: +/0/65535   [???] -->
+		<!-- Control 0xa9: +/0/65535   [???] -->
+		<!-- Control 0xaa: +/0/65535   [???] -->
+		<!-- Control 0xab: +/0/65535   [???] -->
+		<!-- Control 0xac: +/100/0 C [???] -->
+		<!-- Control 0xad: +/0/65535   [???] -->
+		<!-- Control 0xae: +/1/0 C [???] -->
+		<!-- Control 0xaf: +/0/65535   [???] -->
+		<!-- Control 0xb0: +/0/65535   [???] -->
+		<!-- Control 0xb1: +/0/65535   [???] -->
+		<!-- Control 0xb2: +/0/65535 C [???] -->
+		<!-- Control 0xb3: +/0/65535   [???] -->
+		<!-- Control 0xb4: +/0/65535   [???] -->
+		<!-- Control 0xb5: +/0/65535   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/0/65535   [???] -->
+		<!-- Control 0xb8: +/0/65535   [???] -->
+		<!-- Control 0xb9: +/0/65535   [???] -->
+		<!-- Control 0xba: +/0/65535   [???] -->
+		<!-- Control 0xbb: +/0/65535   [???] -->
+		<!-- Control 0xbc: +/0/65535   [???] -->
+		<!-- Control 0xbd: +/0/65535   [???] -->
+		<!-- Control 0xbe: +/0/65535   [???] -->
+		<!-- Control 0xbf: +/0/65535   [???] -->
+		<!-- Control 0xc0: +/5441/65535   [???] -->
+		<!-- Control 0xc1: +/0/65535   [???] -->
+		<!-- Control 0xc2: +/0/65535   [???] -->
+		<!-- Control 0xc3: +/0/65535   [???] -->
+		<!-- Control 0xc4: +/0/65535   [???] -->
+		<!-- Control 0xc5: +/0/65535   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc7: +/0/65535   [???] -->
+		<!-- Control 0xc8: +/5/255 C [???] -->
+		<!-- Control 0xc9: +/775/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcb: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/0/255   [???] -->
+		<!-- Control 0xcd: +/0/65535   [???] -->
+		<!-- Control 0xce: +/0/65535   [???] -->
+		<!-- Control 0xcf: +/0/65535   [???] -->
+		<!-- Control 0xd0: +/0/65535   [???] -->
+		<!-- Control 0xd1: +/0/65535   [???] -->
+		<!-- Control 0xd2: +/0/65535   [???] -->
+		<!-- Control 0xd3: +/0/65535   [???] -->
+		<!-- Control 0xd4: +/0/65535   [???] -->
+		<!-- Control 0xd5: +/0/65535   [???] -->
+		<!-- Control 0xd7: +/0/65535   [???] -->
+		<!-- Control 0xd8: +/0/65535   [???] -->
+		<!-- Control 0xd9: +/0/65535   [???] -->
+		<!-- Control 0xda: +/0/65535   [???] -->
+		<!-- Control 0xdb: +/0/65535   [???] -->
+		<!-- Control 0xdc: +/0/65535   [???] -->
+		<!-- Control 0xdd: +/0/65535   [???] -->
+		<!-- Control 0xde: +/0/65535   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/65535   [???] -->
+		<!-- Control 0xe1: +/0/65535   [???] -->
+		<!-- Control 0xe2: +/0/65535   [???] -->
+		<!-- Control 0xe3: +/0/65535   [???] -->
+		<!-- Control 0xe4: +/0/255   [???] -->
+		<!-- Control 0xe5: +/0/179   [???] -->
+		<!-- Control 0xe6: +/0/16   [???] -->
+		<!-- Control 0xe7: +/0/16   [???] -->
+		<!-- Control 0xe8: +/0/255   [???] -->
+		<!-- Control 0xe9: +/2/255   [???] -->
+		<!-- Control 0xea: +/0/255   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xec: +/0/65535   [???] -->
+		<!-- Control 0xed: +/0/65535   [???] -->
+		<!-- Control 0xee: +/0/65535   [???] -->
+		<!-- Control 0xef: +/0/65535   [???] -->
+		<!-- Control 0xf0: +/0/65535   [???] -->
+		<!-- Control 0xf1: +/0/65535   [???] -->
+		<!-- Control 0xf2: +/0/65535   [???] -->
+		<!-- Control 0xf3: +/0/65535   [???] -->
+		<!-- Control 0xf4: +/0/65535   [???] -->
+		<!-- Control 0xf5: +/0/65535   [???] -->
+		<!-- Control 0xf6: +/0/65535   [???] -->
+		<!-- Control 0xf7: +/0/65535   [???] -->
+		<!-- Control 0xf8: +/0/65535   [???] -->
+		<!-- Control 0xf9: +/0/65535   [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/0/65535   [???] -->
+		<!-- Control 0xfc: +/0/65535   [???] -->
+		<!-- Control 0xfe: +/2/255 C [???] -->
+		<!-- Control 0xff: +/0/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5BB2.xml
+++ b/db/monitor/GSM5BB2.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/239 -->
+<monitor name="LG 24GN600-B" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/20/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/31/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/11/65535 C [???] -->
+		<!-- Control 0x15: +/45/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x4d: +/2/65535 C [???] -->
+		<!-- Control 0x4e: +/0/65535 C [???] -->
+		<!-- Control 0x4f: +/7042/65535 C [???] -->
+		<!-- Control 0x50: +/2/15   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x55: +/1/1   [???] -->
+		<!-- Control 0x69: +/6500/65535   [???] -->
+		<!-- Control 0x6a: +/527/65535   [???] -->
+		<!-- Control 0x6c: +/128/100   [???] -->
+		<!-- Control 0x6e: +/128/100   [???] -->
+		<!-- Control 0x70: +/128/100   [???] -->
+		<!-- Control 0x72: +/30720/65535   [???] -->
+		<!-- Control 0x7a: +/240/65535   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0xac: +/35628/2 C [???] -->
+		<!-- Control 0xae: +/16670/0 C [???] -->
+		<!-- Control 0xaf: +/512/255   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/296/65535 C [???] -->
+		<!-- Control 0xc1: +/20/300   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc8: +/5/255 C [???] -->
+		<!-- Control 0xc9: +/788/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/3/16   [???] -->
+		<!-- Control 0xcf: +/782/65535   [???] -->
+		<!-- Control 0xd7: +/1/255   [???] -->
+		<!-- Control 0xd8: +/1/255   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe2: +/1/65535   [???] -->
+		<!-- Control 0xe4: +/0/255   [???] -->
+		<!-- Control 0xe5: +/0/179   [???] -->
+		<!-- Control 0xe7: +/0/65535   [???] -->
+		<!-- Control 0xe8: +/0/255   [???] -->
+		<!-- Control 0xe9: +/2/255   [???] -->
+		<!-- Control 0xea: +/0/255   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xef: +/100/65535 C [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/2/255 C [???] -->
+		<!-- Control 0xf7: +/3/255 C [???] -->
+		<!-- Control 0xf8: +/3/255 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+		<!-- Control 0xfa: +/2/255 C [???] -->
+		<!-- Control 0xfb: +/2/15   [???] -->
+		<!-- Control 0xfe: +/3/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM5BB4.xml
+++ b/db/monitor/GSM5BB4.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/175 -->
+<monitor name="LG 27GN800-B" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/32/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/65502/65535 C [???] -->
+		<!-- Control 0x15: +/45/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x4d: +/2/65535 C [???] -->
+		<!-- Control 0x4e: +/0/65535 C [???] -->
+		<!-- Control 0x4f: +/7042/65535 C [???] -->
+		<!-- Control 0x50: +/2/15   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x55: +/1/1   [???] -->
+		<!-- Control 0x69: +/6500/65535   [???] -->
+		<!-- Control 0x6a: +/527/65535   [???] -->
+		<!-- Control 0x6c: +/128/100   [???] -->
+		<!-- Control 0x6e: +/128/100   [???] -->
+		<!-- Control 0x70: +/128/100   [???] -->
+		<!-- Control 0x72: +/30720/65535   [???] -->
+		<!-- Control 0x7a: +/240/65535   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0xac: +/25592/3 C [???] -->
+		<!-- Control 0xae: +/22220/0 C [???] -->
+		<!-- Control 0xaf: +/65280/255   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/1094/65535 C [???] -->
+		<!-- Control 0xc1: +/32/300   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc8: +/5/255 C [???] -->
+		<!-- Control 0xc9: +/770/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/0/16   [???] -->
+		<!-- Control 0xcf: +/770/65535   [???] -->
+		<!-- Control 0xd7: +/1/255   [???] -->
+		<!-- Control 0xd8: +/1/255   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe2: +/1/65535   [???] -->
+		<!-- Control 0xe4: +/0/255   [???] -->
+		<!-- Control 0xe5: +/0/179   [???] -->
+		<!-- Control 0xe7: +/0/65535   [???] -->
+		<!-- Control 0xe8: +/0/255   [???] -->
+		<!-- Control 0xe9: +/2/255   [???] -->
+		<!-- Control 0xea: +/0/255   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xef: +/96/65535 C [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/1/255 C [???] -->
+		<!-- Control 0xf7: +/2/255 C [???] -->
+		<!-- Control 0xf8: +/1/255 C [???] -->
+		<!-- Control 0xf9: +/60/255 C [???] -->
+		<!-- Control 0xfa: +/2/255 C [???] -->
+		<!-- Control 0xfb: +/2/15   [???] -->
+		<!-- Control 0xfe: +/3/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM76D8.xml
+++ b/db/monitor/GSM76D8.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/86 -->
+<monitor name="LG 34UM95" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/80/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/0/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/0/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/0/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/0/0   [???] -->
+		<!-- Control 0x01: +/0/0   [???] -->
+		<!-- Control 0x03: +/0/0 C [???] -->
+		<!-- Control 0x06: +/0/0   [???] -->
+		<!-- Control 0x07: +/0/0   [???] -->
+		<!-- Control 0x09: +/0/0   [???] -->
+		<!-- Control 0x0a: +/0/0   [???] -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/70/170 C [???] -->
+		<!-- Control 0x0d: +/0/0   [???] -->
+		<!-- Control 0x0e: +/0/0   [???] -->
+		<!-- Control 0x0f: +/0/0   [???] -->
+		<!-- Control 0x11: +/0/0   [???] -->
+		<!-- Control 0x13: +/0/0   [???] -->
+		<!-- Control 0x14: +/7/11 C [???] -->
+		<!-- Control 0x15: +/0/0   [???] -->
+		<!-- Control 0x17: +/0/0   [???] -->
+		<!-- Control 0x19: +/0/0   [???] -->
+		<!-- Control 0x1b: +/0/0   [???] -->
+		<!-- Control 0x1c: +/0/0   [???] -->
+		<!-- Control 0x1d: +/0/0   [???] -->
+		<!-- Control 0x1e: +/0/0   [???] -->
+		<!-- Control 0x1f: +/0/0   [???] -->
+		<!-- Control 0x20: +/0/0   [???] -->
+		<!-- Control 0x21: +/0/0   [???] -->
+		<!-- Control 0x22: +/0/0   [???] -->
+		<!-- Control 0x23: +/0/0   [???] -->
+		<!-- Control 0x24: +/0/0   [???] -->
+		<!-- Control 0x25: +/0/0   [???] -->
+		<!-- Control 0x26: +/0/0   [???] -->
+		<!-- Control 0x27: +/0/0   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/0/0   [???] -->
+		<!-- Control 0x2c: +/0/0   [???] -->
+		<!-- Control 0x2d: +/0/0   [???] -->
+		<!-- Control 0x2e: +/0/0   [???] -->
+		<!-- Control 0x2f: +/0/0   [???] -->
+		<!-- Control 0x30: +/0/0   [???] -->
+		<!-- Control 0x31: +/0/0   [???] -->
+		<!-- Control 0x32: +/0/0   [???] -->
+		<!-- Control 0x33: +/0/0   [???] -->
+		<!-- Control 0x34: +/0/0   [???] -->
+		<!-- Control 0x35: +/0/0   [???] -->
+		<!-- Control 0x36: +/0/0   [???] -->
+		<!-- Control 0x37: +/0/0   [???] -->
+		<!-- Control 0x38: +/0/0   [???] -->
+		<!-- Control 0x39: +/0/0   [???] -->
+		<!-- Control 0x3a: +/0/0   [???] -->
+		<!-- Control 0x3b: +/0/0   [???] -->
+		<!-- Control 0x3c: +/0/0   [???] -->
+		<!-- Control 0x3d: +/0/0   [???] -->
+		<!-- Control 0x3e: +/0/0   [???] -->
+		<!-- Control 0x3f: +/0/0   [???] -->
+		<!-- Control 0x40: +/0/0   [???] -->
+		<!-- Control 0x41: +/0/0   [???] -->
+		<!-- Control 0x42: +/0/0   [???] -->
+		<!-- Control 0x43: +/0/0   [???] -->
+		<!-- Control 0x44: +/0/0   [???] -->
+		<!-- Control 0x45: +/0/0   [???] -->
+		<!-- Control 0x46: +/0/0   [???] -->
+		<!-- Control 0x47: +/0/0   [???] -->
+		<!-- Control 0x48: +/0/0   [???] -->
+		<!-- Control 0x49: +/0/0   [???] -->
+		<!-- Control 0x4a: +/0/0   [???] -->
+		<!-- Control 0x4b: +/0/0   [???] -->
+		<!-- Control 0x4c: +/0/0   [???] -->
+		<!-- Control 0x4d: +/0/0   [???] -->
+		<!-- Control 0x4e: +/0/0   [???] -->
+		<!-- Control 0x4f: +/0/0   [???] -->
+		<!-- Control 0x50: +/0/0   [???] -->
+		<!-- Control 0x51: +/0/0   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x53: +/0/0   [???] -->
+		<!-- Control 0x54: +/0/0   [???] -->
+		<!-- Control 0x55: +/0/0   [???] -->
+		<!-- Control 0x56: +/0/0   [???] -->
+		<!-- Control 0x57: +/0/0   [???] -->
+		<!-- Control 0x58: +/0/0   [???] -->
+		<!-- Control 0x59: +/0/0   [???] -->
+		<!-- Control 0x5a: +/0/0   [???] -->
+		<!-- Control 0x5b: +/0/0   [???] -->
+		<!-- Control 0x5c: +/0/0   [???] -->
+		<!-- Control 0x5d: +/0/0   [???] -->
+		<!-- Control 0x5e: +/0/0   [???] -->
+		<!-- Control 0x5f: +/0/0   [???] -->
+		<!-- Control 0x61: +/0/0   [???] -->
+		<!-- Control 0x62: +/95/100   [???] -->
+		<!-- Control 0x63: +/0/0   [???] -->
+		<!-- Control 0x64: +/0/0   [???] -->
+		<!-- Control 0x65: +/0/0   [???] -->
+		<!-- Control 0x66: +/0/0   [???] -->
+		<!-- Control 0x67: +/0/0   [???] -->
+		<!-- Control 0x68: +/0/0   [???] -->
+		<!-- Control 0x69: +/0/0   [???] -->
+		<!-- Control 0x6a: +/0/0   [???] -->
+		<!-- Control 0x6b: +/0/0   [???] -->
+		<!-- Control 0x6d: +/0/0   [???] -->
+		<!-- Control 0x6f: +/0/0   [???] -->
+		<!-- Control 0x71: +/0/0   [???] -->
+		<!-- Control 0x72: +/0/0   [???] -->
+		<!-- Control 0x73: +/0/0   [???] -->
+		<!-- Control 0x74: +/0/0   [???] -->
+		<!-- Control 0x75: +/0/0   [???] -->
+		<!-- Control 0x76: +/0/0   [???] -->
+		<!-- Control 0x77: +/0/0   [???] -->
+		<!-- Control 0x78: +/0/0   [???] -->
+		<!-- Control 0x79: +/0/0   [???] -->
+		<!-- Control 0x7a: +/0/0   [???] -->
+		<!-- Control 0x7b: +/0/0   [???] -->
+		<!-- Control 0x7c: +/0/0   [???] -->
+		<!-- Control 0x7d: +/0/0   [???] -->
+		<!-- Control 0x7e: +/0/0   [???] -->
+		<!-- Control 0x7f: +/0/0   [???] -->
+		<!-- Control 0x80: +/0/0   [???] -->
+		<!-- Control 0x81: +/0/0   [???] -->
+		<!-- Control 0x82: +/0/0   [???] -->
+		<!-- Control 0x83: +/0/0   [???] -->
+		<!-- Control 0x84: +/0/0   [???] -->
+		<!-- Control 0x85: +/0/0   [???] -->
+		<!-- Control 0x86: +/0/0   [???] -->
+		<!-- Control 0x87: +/0/0 C [???] -->
+		<!-- Control 0x88: +/0/0   [???] -->
+		<!-- Control 0x89: +/0/0   [???] -->
+		<!-- Control 0x8a: +/0/0   [???] -->
+		<!-- Control 0x8b: +/0/0   [???] -->
+		<!-- Control 0x8c: +/0/0   [???] -->
+		<!-- Control 0x8d: +/2/2   [???] -->
+		<!-- Control 0x8e: +/0/0   [???] -->
+		<!-- Control 0x8f: +/0/0   [???] -->
+		<!-- Control 0x90: +/0/0   [???] -->
+		<!-- Control 0x91: +/0/0   [???] -->
+		<!-- Control 0x92: +/0/0   [???] -->
+		<!-- Control 0x93: +/0/0   [???] -->
+		<!-- Control 0x94: +/0/0   [???] -->
+		<!-- Control 0x95: +/0/0   [???] -->
+		<!-- Control 0x96: +/0/0   [???] -->
+		<!-- Control 0x97: +/0/0   [???] -->
+		<!-- Control 0x98: +/0/0   [???] -->
+		<!-- Control 0x99: +/0/0   [???] -->
+		<!-- Control 0x9a: +/0/0   [???] -->
+		<!-- Control 0x9b: +/0/0   [???] -->
+		<!-- Control 0x9c: +/0/0   [???] -->
+		<!-- Control 0x9d: +/0/0   [???] -->
+		<!-- Control 0x9e: +/0/0   [???] -->
+		<!-- Control 0x9f: +/0/0   [???] -->
+		<!-- Control 0xa0: +/0/0   [???] -->
+		<!-- Control 0xa1: +/0/0   [???] -->
+		<!-- Control 0xa2: +/0/0   [???] -->
+		<!-- Control 0xa3: +/0/0   [???] -->
+		<!-- Control 0xa4: +/0/0   [???] -->
+		<!-- Control 0xa5: +/0/0   [???] -->
+		<!-- Control 0xa6: +/0/0   [???] -->
+		<!-- Control 0xa7: +/0/0   [???] -->
+		<!-- Control 0xa8: +/0/0   [???] -->
+		<!-- Control 0xa9: +/0/0   [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xab: +/0/0   [???] -->
+		<!-- Control 0xac: +/23264/1 C [???] -->
+		<!-- Control 0xad: +/0/0   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/0/0   [???] -->
+		<!-- Control 0xb0: +/0/0   [???] -->
+		<!-- Control 0xb1: +/0/0   [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb3: +/0/0   [???] -->
+		<!-- Control 0xb4: +/0/0   [???] -->
+		<!-- Control 0xb5: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xb7: +/0/0   [???] -->
+		<!-- Control 0xb8: +/0/0   [???] -->
+		<!-- Control 0xb9: +/0/0   [???] -->
+		<!-- Control 0xba: +/0/0   [???] -->
+		<!-- Control 0xbb: +/0/0   [???] -->
+		<!-- Control 0xbc: +/0/0   [???] -->
+		<!-- Control 0xbd: +/0/0   [???] -->
+		<!-- Control 0xbe: +/0/0   [???] -->
+		<!-- Control 0xbf: +/0/0   [???] -->
+		<!-- Control 0xc0: +/66/65535 C [???] -->
+		<!-- Control 0xc1: +/0/0   [???] -->
+		<!-- Control 0xc2: +/0/0   [???] -->
+		<!-- Control 0xc3: +/0/0   [???] -->
+		<!-- Control 0xc4: +/0/0   [???] -->
+		<!-- Control 0xc5: +/0/0   [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc7: +/0/0   [???] -->
+		<!-- Control 0xc8: +/19/65535 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcb: +/0/0   [???] -->
+		<!-- Control 0xcc: +/2/255   [???] -->
+		<!-- Control 0xcd: +/0/0   [???] -->
+		<!-- Control 0xce: +/0/0   [???] -->
+		<!-- Control 0xcf: +/0/0   [???] -->
+		<!-- Control 0xd0: +/0/0   [???] -->
+		<!-- Control 0xd1: +/0/0   [???] -->
+		<!-- Control 0xd2: +/0/0   [???] -->
+		<!-- Control 0xd3: +/0/0   [???] -->
+		<!-- Control 0xd4: +/0/0   [???] -->
+		<!-- Control 0xd5: +/0/0   [???] -->
+		<!-- Control 0xd7: +/0/0   [???] -->
+		<!-- Control 0xd8: +/0/0   [???] -->
+		<!-- Control 0xd9: +/0/0   [???] -->
+		<!-- Control 0xda: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/0   [???] -->
+		<!-- Control 0xdc: +/0/3   [???] -->
+		<!-- Control 0xdd: +/0/0   [???] -->
+		<!-- Control 0xde: +/0/0   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/0/0   [???] -->
+		<!-- Control 0xe1: +/0/0   [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/0   [???] -->
+		<!-- Control 0xe4: +/0/65535 C [???] -->
+		<!-- Control 0xe5: +/0/34 C [???] -->
+		<!-- Control 0xe6: +/0/65535 C [???] -->
+		<!-- Control 0xe7: +/0/0 C [???] -->
+		<!-- Control 0xe8: +/0/65535 C [???] -->
+		<!-- Control 0xe9: +/2/65535 C [???] -->
+		<!-- Control 0xea: +/0/0 C [???] -->
+		<!-- Control 0xeb: +/0/2 C [???] -->
+		<!-- Control 0xec: +/0/0   [???] -->
+		<!-- Control 0xed: +/64/65535   [???] -->
+		<!-- Control 0xee: +/0/65535 C [???] -->
+		<!-- Control 0xef: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/0   [???] -->
+		<!-- Control 0xf1: +/0/0   [???] -->
+		<!-- Control 0xf2: +/0/0   [???] -->
+		<!-- Control 0xf3: +/0/0   [???] -->
+		<!-- Control 0xf4: +/0/0   [???] -->
+		<!-- Control 0xf5: +/0/0   [???] -->
+		<!-- Control 0xf6: +/0/0   [???] -->
+		<!-- Control 0xf7: +/0/0   [???] -->
+		<!-- Control 0xf8: +/0/0   [???] -->
+		<!-- Control 0xf9: +/0/0   [???] -->
+		<!-- Control 0xfa: +/0/0   [???] -->
+		<!-- Control 0xfb: +/0/0   [???] -->
+		<!-- Control 0xfc: +/0/0   [???] -->
+		<!-- Control 0xfd: +/0/0   [???] -->
+		<!-- Control 0xfe: +/2/3 C [???] -->
+		<!-- Control 0xff: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/GSM76FA.xml
+++ b/db/monitor/GSM76FA.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/64 -->
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/317 -->
+<monitor name="LG 29UM69G-B" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/36/100 C [Brightness] -->
+		<!-- Control 0x12: +/67/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/10/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x62: +/30/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/0/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0x60: +/0/18 C [Input Source Select] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x15: +/14/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x4d: +/30771/65535 C [???] -->
+		<!-- Control 0x4e: +/16384/65535 C [???] -->
+		<!-- Control 0x4f: +/0/65535 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/128/100   [???] -->
+		<!-- Control 0x6e: +/128/100   [???] -->
+		<!-- Control 0x70: +/128/100   [???] -->
+		<!-- Control 0x87: +/100/100   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0xac: +/1064/1 C [???] -->
+		<!-- Control 0xae: +/6660/0 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/4038/65535 C [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc8: +/9/255 C [???] -->
+		<!-- Control 0xc9: +/792/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/3/16   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe4: +/0/255 C [???] -->
+		<!-- Control 0xe5: +/35/0 C [???] -->
+		<!-- Control 0xe6: +/0/65535 C [???] -->
+		<!-- Control 0xe7: +/0/65535 C [???] -->
+		<!-- Control 0xe8: +/0/255 C [???] -->
+		<!-- Control 0xe9: +/2/255 C [???] -->
+		<!-- Control 0xea: +/0/255 C [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xef: +/0/65535 C [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/2/255 C [???] -->
+		<!-- Control 0xf6: +/0/255 C [???] -->
+		<!-- Control 0xf7: +/2/255 C [???] -->
+		<!-- Control 0xf8: +/255/255 C [???] -->
+		<!-- Control 0xf9: +/65/255 C [???] -->
+		<!-- Control 0xfa: +/2/255 C [???] -->
+		<!-- Control 0xfb: +/2/65535   [???] -->
+		<!-- Control 0xfe: +/3/255 C [???] -->
+		<!-- Control 0x15: +/11/255 C [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0xac: +/1164/1 C [???] -->
+		<!-- Control 0xae: +/6670/0 C [???] -->
+		<!-- Control 0xc0: +/135/65535 C [???] -->
+		<!-- Control 0xc9: +/790/65535 C [???] -->
+		<!-- Control 0xcc: +/0/16   [???] -->
+		<!-- Control 0xf4: +/30/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/1/255 C [???] -->
+		<!-- Control 0xf8: +/0/255 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HPN3474.xml
+++ b/db/monitor/HPN3474.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/68 -->
+<monitor name="HP E273q" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/77/100 C [Contrast] -->
+		<!-- Control 0x16: +/241/255 C [Red maximum level] -->
+		<!-- Control 0x18: +/242/255 C [Green maximum level] -->
+		<!-- Control 0x1a: +/245/255 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/128/255 C [Red minimum level] -->
+		<!-- Control 0x6e: +/128/255 C [Green minimum level] -->
+		<!-- Control 0x70: +/128/255 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/19 C [Input Source Select] -->
+		<!-- Control 0xaa: +/1/4 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/0/63 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x2e: +/0/3 C [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x52: +/220/255 C [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x86: +/2/5 C [???] -->
+		<!-- Control 0x87: +/4/7 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc0: +/6/65535 C [???] -->
+		<!-- Control 0xc6: +/90/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/256/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdc: +/2/6 C [???] -->
+		<!-- Control 0xdf: +/514/255 C [???] -->
+		<!-- Control 0xe6: +/1/1 C [???] -->
+		<!-- Control 0xe7: +/0/1 C [???] -->
+		<!-- Control 0xe9: +/1/1 C [???] -->
+		<!-- Control 0xea: +/0/1 C [???] -->
+		<!-- Control 0xeb: +/1/5 C [???] -->
+		<!-- Control 0xee: +/3/3 C [???] -->
+		<!-- Control 0xef: +/1281/0 C [???] -->
+		<!-- Control 0xf0: +/22/1281 C [???] -->
+		<!-- Control 0xfa: +/0/65535 C [???] -->
+		<!-- Control 0xfb: +/5/255 C [???] -->
+		<!-- Control 0xfc: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/0/65535 C [???] -->
+		<!-- Control 0xfe: +/0/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HPN36D2.xml
+++ b/db/monitor/HPN36D2.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/234 -->
+<monitor name="HP Z27u G3" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/100/100 C [Contrast] -->
+		<!-- Control 0x16: +/255/255 C [Red maximum level] -->
+		<!-- Control 0x18: +/253/255 C [Green maximum level] -->
+		<!-- Control 0x1a: +/254/255 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/128/255 C [Red minimum level] -->
+		<!-- Control 0x6e: +/128/255 C [Green minimum level] -->
+		<!-- Control 0x70: +/128/255 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/19 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/50 C [???] -->
+		<!-- Control 0x0c: +/0/126 C [???] -->
+		<!-- Control 0x14: +/1/37   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x2e: +/0/3 C [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x86: +/2/5 C [???] -->
+		<!-- Control 0x87: +/4/7 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xaa: +/2/4   [???] -->
+		<!-- Control 0xac: +/22664/1 C [???] -->
+		<!-- Control 0xae: +/5960/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc0: +/18/65535 C [???] -->
+		<!-- Control 0xc6: +/90/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/256/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xda: +/0/3 C [???] -->
+		<!-- Control 0xdc: +/1/34 C [???] -->
+		<!-- Control 0xdf: +/514/255   [???] -->
+		<!-- Control 0xe0: +/0/0   [???] -->
+		<!-- Control 0xe1: +/0/0   [???] -->
+		<!-- Control 0xe2: +/0/0   [???] -->
+		<!-- Control 0xe3: +/0/0   [???] -->
+		<!-- Control 0xe5: +/1/255   [???] -->
+		<!-- Control 0xe6: +/1/1   [???] -->
+		<!-- Control 0xe7: +/1/1   [???] -->
+		<!-- Control 0xe8: +/1/2   [???] -->
+		<!-- Control 0xe9: +/0/1   [???] -->
+		<!-- Control 0xea: +/0/1   [???] -->
+		<!-- Control 0xeb: +/0/255   [???] -->
+		<!-- Control 0xec: +/0/7   [???] -->
+		<!-- Control 0xee: +/2/3   [???] -->
+		<!-- Control 0xef: +/1281/0   [???] -->
+		<!-- Control 0xf0: +/32/1281   [???] -->
+		<!-- Control 0xf4: +/0/255   [???] -->
+		<!-- Control 0xf5: +/519/512   [???] -->
+		<!-- Control 0xf6: +/0/0   [???] -->
+		<!-- Control 0xf7: +/1/255   [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/5/255   [???] -->
+		<!-- Control 0xfc: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/0/65535   [???] -->
+		<!-- Control 0xfe: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HWP26E0.xml
+++ b/db/monitor/HWP26E0.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/89 -->
+<monitor name="HP w17e" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/80/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/65535 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/32/64 C [Vertical Position] -->
+		<!-- Control 0x3e: +/9/100 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/0/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/65535 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/65535 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/65535 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/65535 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/3000/12288 C [???] -->
+		<!-- Control 0x0c: +/2/2 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1f: +/0/65535 C [???] -->
+		<!-- Control 0x52: +/194/255 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/70/65535 C [???] -->
+		<!-- Control 0xae: +/75/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/8969/65535 C [???] -->
+		<!-- Control 0xc9: +/512/255 C [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/2/9 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HWP26F8.xml
+++ b/db/monitor/HWP26F8.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/31 -->
+<monitor name="HP LP2475w" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/77/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/255/255 C [Red maximum level] -->
+		<!-- Control 0x18: +/255/255 C [Green maximum level] -->
+		<!-- Control 0x1a: +/255/255 C [Blue maximum level] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/19/28 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/3000/65535 C [???] -->
+		<!-- Control 0x0c: +/1/2 C [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/65535   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x3e: +/0/63   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x9b: +/127/254 C [???] -->
+		<!-- Control 0x9c: +/127/254 C [???] -->
+		<!-- Control 0x9d: +/127/254 C [???] -->
+		<!-- Control 0x9e: +/127/254 C [???] -->
+		<!-- Control 0x9f: +/127/254 C [???] -->
+		<!-- Control 0xa0: +/127/254 C [???] -->
+		<!-- Control 0xac: +/8364/1 C [???] -->
+		<!-- Control 0xae: +/5980/65535 C [???] -->
+		<!-- Control 0xb2: +/1/65535 C [???] -->
+		<!-- Control 0xb6: +/3/65535 C [???] -->
+		<!-- Control 0xc0: +/6837/65535 C [???] -->
+		<!-- Control 0xc6: +/90/65535 C [???] -->
+		<!-- Control 0xc8: +/32770/65535 C [???] -->
+		<!-- Control 0xc9: +/52/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/20 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xfa: +/0/2 C [???] -->
+		<!-- Control 0xfb: +/0/65535 C [???] -->
+		<!-- Control 0xfc: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/0/65535 C [???] -->
+		<!-- Control 0xfe: +/0/4 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/HWP26FB.xml
+++ b/db/monitor/HWP26FB.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/57 -->
+<monitor name="HP L2245wg" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/60/120 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/90/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/255/255 C [Red maximum level] -->
+		<!-- Control 0x18: +/255/255 C [Green maximum level] -->
+		<!-- Control 0x1a: +/255/255 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/255 C [Automatically adjust] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/50/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/46/60 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/2/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/2/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/2/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x0b: +/3000/65535 C [???] -->
+		<!-- Control 0x0c: +/1/2 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1f: +/0/255 C [???] -->
+		<!-- Control 0x52: +/81/65535 C [???] -->
+		<!-- Control 0xac: +/64/1 C [???] -->
+		<!-- Control 0xae: +/6030/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb6: +/3/0 C [???] -->
+		<!-- Control 0xc0: +/7237/65535 C [???] -->
+		<!-- Control 0xc6: +/90/65535 C [???] -->
+		<!-- Control 0xc8: +/9/9509 C [???] -->
+		<!-- Control 0xc9: +/256/0 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/21 C [???] -->
+		<!-- Control 0xdf: +/513/0 C [???] -->
+		<!-- Control 0xfa: +/0/255 C [???] -->
+		<!-- Control 0xfb: +/0/60 C [???] -->
+		<!-- Control 0xfc: +/0/65535 C [???] -->
+		<!-- Control 0xfd: +/0/65535 C [???] -->
+		<!-- Control 0xfe: +/0/255 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/IVM5398.xml
+++ b/db/monitor/IVM5398.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/16 -->
+<monitor name="IIyama ProLite E2003WS" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 3E 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/74/100 C [Brightness] -->
+		<!-- Control 0x12: +/22/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x3e: +/0/63 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/2 C [???] -->
+		<!-- Control 0x0b: +/2/2 [???] -->
+		<!-- Control 0x0c: +/2/2 [???] -->
+		<!-- Control 0x0e: +/100/100 [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/255 [???] -->
+		<!-- Control 0x1f: +/0/255 [???] -->
+		<!-- Control 0x20: +/0/100 [???] -->
+		<!-- Control 0x30: +/147/100 [???] -->
+		<!-- Control 0x52: +/0/2 C [???] -->
+		<!-- Control 0xac: +/64900/0 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/3833/65535 C [???] -->
+		<!-- Control 0xc8: +/18697/37 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 [???] -->
+		<!-- Control 0xcc: +/30/16 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/IVM6637.xml
+++ b/db/monitor/IVM6637.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/159 -->
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/304 -->
+<monitor name="Iiyama ProLite XUB2792QSU" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/40/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/80/100 C [Contrast] -->
+		<!-- Control 0x16: +/97/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/95/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/99/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/15 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x00: +/30309/10664   [???] -->
+		<!-- Control 0x01: +/30309/10664   [???] -->
+		<!-- Control 0x03: +/1/2   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x07: +/0/1   [???] -->
+		<!-- Control 0x09: +/0/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/100/0 C [???] -->
+		<!-- Control 0x0d: +/100/0   [???] -->
+		<!-- Control 0x0e: +/100/0   [???] -->
+		<!-- Control 0x0f: +/100/0   [???] -->
+		<!-- Control 0x11: +/40/100   [???] -->
+		<!-- Control 0x13: +/75/100   [???] -->
+		<!-- Control 0x14: +/11/12 C [???] -->
+		<!-- Control 0x15: +/11/12   [???] -->
+		<!-- Control 0x17: +/100/100   [???] -->
+		<!-- Control 0x19: +/100/100   [???] -->
+		<!-- Control 0x1b: +/100/100   [???] -->
+		<!-- Control 0x1c: +/100/100   [???] -->
+		<!-- Control 0x1d: +/100/100   [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x21: +/0/1   [???] -->
+		<!-- Control 0x22: +/0/1   [???] -->
+		<!-- Control 0x23: +/0/1   [???] -->
+		<!-- Control 0x24: +/0/1   [???] -->
+		<!-- Control 0x25: +/0/1   [???] -->
+		<!-- Control 0x26: +/0/1   [???] -->
+		<!-- Control 0x27: +/0/1   [???] -->
+		<!-- Control 0x28: +/0/1   [???] -->
+		<!-- Control 0x29: +/0/1   [???] -->
+		<!-- Control 0x2a: +/0/1   [???] -->
+		<!-- Control 0x2b: +/0/1   [???] -->
+		<!-- Control 0x2c: +/0/1   [???] -->
+		<!-- Control 0x2d: +/0/1   [???] -->
+		<!-- Control 0x2e: +/0/1   [???] -->
+		<!-- Control 0x2f: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x31: +/0/1   [???] -->
+		<!-- Control 0x32: +/0/1   [???] -->
+		<!-- Control 0x33: +/0/1   [???] -->
+		<!-- Control 0x34: +/0/1   [???] -->
+		<!-- Control 0x35: +/0/1   [???] -->
+		<!-- Control 0x36: +/0/1   [???] -->
+		<!-- Control 0x37: +/0/1   [???] -->
+		<!-- Control 0x38: +/0/1   [???] -->
+		<!-- Control 0x39: +/0/1   [???] -->
+		<!-- Control 0x3a: +/0/1   [???] -->
+		<!-- Control 0x3b: +/0/1   [???] -->
+		<!-- Control 0x3c: +/0/1   [???] -->
+		<!-- Control 0x3d: +/0/1   [???] -->
+		<!-- Control 0x3e: +/0/1   [???] -->
+		<!-- Control 0x3f: +/0/1   [???] -->
+		<!-- Control 0x40: +/0/1   [???] -->
+		<!-- Control 0x41: +/0/1   [???] -->
+		<!-- Control 0x42: +/0/1   [???] -->
+		<!-- Control 0x43: +/0/1   [???] -->
+		<!-- Control 0x44: +/0/1   [???] -->
+		<!-- Control 0x45: +/0/1   [???] -->
+		<!-- Control 0x46: +/0/1   [???] -->
+		<!-- Control 0x47: +/0/1   [???] -->
+		<!-- Control 0x48: +/0/1   [???] -->
+		<!-- Control 0x49: +/0/1   [???] -->
+		<!-- Control 0x4a: +/0/1   [???] -->
+		<!-- Control 0x4b: +/0/1   [???] -->
+		<!-- Control 0x4c: +/0/1   [???] -->
+		<!-- Control 0x4d: +/0/1   [???] -->
+		<!-- Control 0x4e: +/0/1   [???] -->
+		<!-- Control 0x4f: +/0/1   [???] -->
+		<!-- Control 0x50: +/0/1   [???] -->
+		<!-- Control 0x51: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x53: +/0/255   [???] -->
+		<!-- Control 0x54: +/0/255   [???] -->
+		<!-- Control 0x55: +/0/255   [???] -->
+		<!-- Control 0x56: +/0/255   [???] -->
+		<!-- Control 0x57: +/0/255   [???] -->
+		<!-- Control 0x58: +/0/255   [???] -->
+		<!-- Control 0x59: +/0/255   [???] -->
+		<!-- Control 0x5a: +/0/255   [???] -->
+		<!-- Control 0x5b: +/0/255   [???] -->
+		<!-- Control 0x5c: +/0/255   [???] -->
+		<!-- Control 0x5d: +/0/255   [???] -->
+		<!-- Control 0x5e: +/0/255   [???] -->
+		<!-- Control 0x5f: +/0/255   [???] -->
+		<!-- Control 0x61: +/15/15   [???] -->
+		<!-- Control 0x62: +/60/100   [???] -->
+		<!-- Control 0x63: +/60/100   [???] -->
+		<!-- Control 0x64: +/60/100   [???] -->
+		<!-- Control 0x65: +/60/100   [???] -->
+		<!-- Control 0x66: +/60/100   [???] -->
+		<!-- Control 0x67: +/60/100   [???] -->
+		<!-- Control 0x68: +/60/100   [???] -->
+		<!-- Control 0x69: +/60/100   [???] -->
+		<!-- Control 0x6a: +/60/100   [???] -->
+		<!-- Control 0x6b: +/60/100   [???] -->
+		<!-- Control 0x6c: +/60/100   [???] -->
+		<!-- Control 0x6d: +/60/100   [???] -->
+		<!-- Control 0x6e: +/60/100   [???] -->
+		<!-- Control 0x6f: +/60/100   [???] -->
+		<!-- Control 0x70: +/60/100   [???] -->
+		<!-- Control 0x71: +/60/100   [???] -->
+		<!-- Control 0x72: +/60/100   [???] -->
+		<!-- Control 0x73: +/60/100   [???] -->
+		<!-- Control 0x74: +/60/100   [???] -->
+		<!-- Control 0x75: +/60/100   [???] -->
+		<!-- Control 0x76: +/60/100   [???] -->
+		<!-- Control 0x77: +/60/100   [???] -->
+		<!-- Control 0x78: +/60/100   [???] -->
+		<!-- Control 0x79: +/60/100   [???] -->
+		<!-- Control 0x7a: +/60/100   [???] -->
+		<!-- Control 0x7b: +/60/100   [???] -->
+		<!-- Control 0x7c: +/60/100   [???] -->
+		<!-- Control 0x7d: +/60/100   [???] -->
+		<!-- Control 0x7e: +/60/100   [???] -->
+		<!-- Control 0x7f: +/60/100   [???] -->
+		<!-- Control 0x80: +/60/100   [???] -->
+		<!-- Control 0x81: +/60/100   [???] -->
+		<!-- Control 0x82: +/60/100   [???] -->
+		<!-- Control 0x83: +/60/100   [???] -->
+		<!-- Control 0x84: +/60/100   [???] -->
+		<!-- Control 0x85: +/60/100   [???] -->
+		<!-- Control 0x86: +/60/100   [???] -->
+		<!-- Control 0x87: +/60/100   [???] -->
+		<!-- Control 0x88: +/60/100   [???] -->
+		<!-- Control 0x89: +/60/100   [???] -->
+		<!-- Control 0x8a: +/60/100   [???] -->
+		<!-- Control 0x8b: +/60/100   [???] -->
+		<!-- Control 0x8c: +/60/100   [???] -->
+		<!-- Control 0x8d: +/2/2   [???] -->
+		<!-- Control 0x8e: +/2/2   [???] -->
+		<!-- Control 0x8f: +/2/2   [???] -->
+		<!-- Control 0x90: +/2/2   [???] -->
+		<!-- Control 0x91: +/2/2   [???] -->
+		<!-- Control 0x92: +/2/2   [???] -->
+		<!-- Control 0x93: +/2/2   [???] -->
+		<!-- Control 0x94: +/2/2   [???] -->
+		<!-- Control 0x95: +/2/2   [???] -->
+		<!-- Control 0x96: +/2/2   [???] -->
+		<!-- Control 0x97: +/2/2   [???] -->
+		<!-- Control 0x98: +/2/2   [???] -->
+		<!-- Control 0x99: +/2/2   [???] -->
+		<!-- Control 0x9a: +/2/2   [???] -->
+		<!-- Control 0x9b: +/2/2   [???] -->
+		<!-- Control 0x9c: +/2/2   [???] -->
+		<!-- Control 0x9d: +/2/2   [???] -->
+		<!-- Control 0x9e: +/2/2   [???] -->
+		<!-- Control 0x9f: +/2/2   [???] -->
+		<!-- Control 0xa0: +/2/2   [???] -->
+		<!-- Control 0xa1: +/2/2   [???] -->
+		<!-- Control 0xa2: +/2/2   [???] -->
+		<!-- Control 0xa3: +/2/2   [???] -->
+		<!-- Control 0xa4: +/2/2   [???] -->
+		<!-- Control 0xa5: +/2/2   [???] -->
+		<!-- Control 0xa6: +/2/2   [???] -->
+		<!-- Control 0xa7: +/2/2   [???] -->
+		<!-- Control 0xa8: +/2/2   [???] -->
+		<!-- Control 0xa9: +/2/2   [???] -->
+		<!-- Control 0xaa: +/2/2   [???] -->
+		<!-- Control 0xab: +/2/2   [???] -->
+		<!-- Control 0xac: +/23264/1 C [???] -->
+		<!-- Control 0xad: +/23264/1   [???] -->
+		<!-- Control 0xae: +/5990/65535 C [???] -->
+		<!-- Control 0xaf: +/5990/65535   [???] -->
+		<!-- Control 0xb0: +/5990/65535   [???] -->
+		<!-- Control 0xb1: +/5990/65535   [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb3: +/1/1   [???] -->
+		<!-- Control 0xb4: +/1/1   [???] -->
+		<!-- Control 0xb5: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/3/5   [???] -->
+		<!-- Control 0xb8: +/3/5   [???] -->
+		<!-- Control 0xb9: +/3/5   [???] -->
+		<!-- Control 0xba: +/3/5   [???] -->
+		<!-- Control 0xbb: +/3/5   [???] -->
+		<!-- Control 0xbc: +/3/5   [???] -->
+		<!-- Control 0xbd: +/3/5   [???] -->
+		<!-- Control 0xbe: +/3/5   [???] -->
+		<!-- Control 0xbf: +/3/5   [???] -->
+		<!-- Control 0xc0: +/7537/65535 C [???] -->
+		<!-- Control 0xc1: +/7537/65535   [???] -->
+		<!-- Control 0xc2: +/7537/65535   [???] -->
+		<!-- Control 0xc3: +/7537/65535   [???] -->
+		<!-- Control 0xc4: +/7537/65535   [???] -->
+		<!-- Control 0xc5: +/7537/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc7: +/17868/65535   [???] -->
+		<!-- Control 0xc8: +/34057/39 C [???] -->
+		<!-- Control 0xc9: +/0/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcb: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/11 C [???] -->
+		<!-- Control 0xcd: +/2/11   [???] -->
+		<!-- Control 0xce: +/2/11   [???] -->
+		<!-- Control 0xcf: +/2/11   [???] -->
+		<!-- Control 0xd0: +/2/11   [???] -->
+		<!-- Control 0xd1: +/2/11   [???] -->
+		<!-- Control 0xd2: +/2/11   [???] -->
+		<!-- Control 0xd3: +/2/11   [???] -->
+		<!-- Control 0xd4: +/2/11   [???] -->
+		<!-- Control 0xd5: +/2/11   [???] -->
+		<!-- Control 0xd7: +/1/5   [???] -->
+		<!-- Control 0xd8: +/1/5   [???] -->
+		<!-- Control 0xd9: +/1/5   [???] -->
+		<!-- Control 0xda: +/1/5   [???] -->
+		<!-- Control 0xdb: +/1/5   [???] -->
+		<!-- Control 0xdc: +/1/5   [???] -->
+		<!-- Control 0xdd: +/1/5   [???] -->
+		<!-- Control 0xde: +/1/5   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/513/65535   [???] -->
+		<!-- Control 0xe1: +/513/65535   [???] -->
+		<!-- Control 0xe2: +/513/65535   [???] -->
+		<!-- Control 0xe3: +/513/65535   [???] -->
+		<!-- Control 0xe4: +/513/65535   [???] -->
+		<!-- Control 0xe5: +/513/65535   [???] -->
+		<!-- Control 0xe6: +/513/65535   [???] -->
+		<!-- Control 0xe7: +/513/65535   [???] -->
+		<!-- Control 0xe8: +/513/65535   [???] -->
+		<!-- Control 0xe9: +/513/65535   [???] -->
+		<!-- Control 0xea: +/513/65535   [???] -->
+		<!-- Control 0xeb: +/513/65535   [???] -->
+		<!-- Control 0xec: +/513/65535   [???] -->
+		<!-- Control 0xed: +/513/65535   [???] -->
+		<!-- Control 0xee: +/513/65535   [???] -->
+		<!-- Control 0xef: +/513/65535   [???] -->
+		<!-- Control 0xf0: +/513/65535   [???] -->
+		<!-- Control 0xf1: +/513/65535   [???] -->
+		<!-- Control 0xf2: +/513/65535   [???] -->
+		<!-- Control 0xf3: +/513/65535   [???] -->
+		<!-- Control 0xf4: +/513/65535   [???] -->
+		<!-- Control 0xf5: +/513/65535   [???] -->
+		<!-- Control 0xf6: +/513/65535   [???] -->
+		<!-- Control 0xf7: +/513/65535   [???] -->
+		<!-- Control 0xf8: +/513/65535   [???] -->
+		<!-- Control 0xf9: +/513/65535   [???] -->
+		<!-- Control 0xfa: +/513/65535   [???] -->
+		<!-- Control 0xfb: +/0/1   [???] -->
+		<!-- Control 0xfc: +/138/255   [???] -->
+		<!-- Control 0xfd: +/98/255   [???] -->
+		<!-- Control 0xfe: +/98/255   [???] -->
+		<!-- Control 0xff: +/98/255   [???] -->
+		<!-- Control 0x11: +/50/100   [???] -->
+		<!-- Control 0x13: +/80/100   [???] -->
+		<!-- Control 0x17: +/97/100   [???] -->
+		<!-- Control 0x19: +/95/100   [???] -->
+		<!-- Control 0x1b: +/99/100   [???] -->
+		<!-- Control 0x1c: +/99/100   [???] -->
+		<!-- Control 0x1d: +/99/100   [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x63: +/100/100   [???] -->
+		<!-- Control 0x64: +/100/100   [???] -->
+		<!-- Control 0x65: +/100/100   [???] -->
+		<!-- Control 0x66: +/100/100   [???] -->
+		<!-- Control 0x67: +/100/100   [???] -->
+		<!-- Control 0x68: +/100/100   [???] -->
+		<!-- Control 0x69: +/100/100   [???] -->
+		<!-- Control 0x6a: +/100/100   [???] -->
+		<!-- Control 0x6b: +/100/100   [???] -->
+		<!-- Control 0x6c: +/100/100   [???] -->
+		<!-- Control 0x6d: +/100/100   [???] -->
+		<!-- Control 0x6e: +/100/100   [???] -->
+		<!-- Control 0x6f: +/100/100   [???] -->
+		<!-- Control 0x70: +/100/100   [???] -->
+		<!-- Control 0x71: +/100/100   [???] -->
+		<!-- Control 0x72: +/100/100   [???] -->
+		<!-- Control 0x73: +/100/100   [???] -->
+		<!-- Control 0x74: +/100/100   [???] -->
+		<!-- Control 0x75: +/100/100   [???] -->
+		<!-- Control 0x76: +/100/100   [???] -->
+		<!-- Control 0x77: +/100/100   [???] -->
+		<!-- Control 0x78: +/100/100   [???] -->
+		<!-- Control 0x79: +/100/100   [???] -->
+		<!-- Control 0x7a: +/100/100   [???] -->
+		<!-- Control 0x7b: +/100/100   [???] -->
+		<!-- Control 0x7c: +/100/100   [???] -->
+		<!-- Control 0x7d: +/100/100   [???] -->
+		<!-- Control 0x7e: +/100/100   [???] -->
+		<!-- Control 0x7f: +/100/100   [???] -->
+		<!-- Control 0x80: +/100/100   [???] -->
+		<!-- Control 0x81: +/100/100   [???] -->
+		<!-- Control 0x82: +/100/100   [???] -->
+		<!-- Control 0x83: +/100/100   [???] -->
+		<!-- Control 0x84: +/100/100   [???] -->
+		<!-- Control 0x85: +/100/100   [???] -->
+		<!-- Control 0x86: +/100/100   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xad: +/23364/1   [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xaf: +/6000/65535   [???] -->
+		<!-- Control 0xb0: +/6000/65535   [???] -->
+		<!-- Control 0xb1: +/6000/65535   [???] -->
+		<!-- Control 0xc0: +/5595/65535 C [???] -->
+		<!-- Control 0xc1: +/5595/65535   [???] -->
+		<!-- Control 0xc2: +/5595/65535   [???] -->
+		<!-- Control 0xc3: +/5595/65535   [???] -->
+		<!-- Control 0xc4: +/5595/65535   [???] -->
+		<!-- Control 0xc5: +/5595/65535   [???] -->
+		<!-- Control 0xcc: +/9/11 C [???] -->
+		<!-- Control 0xcd: +/9/11   [???] -->
+		<!-- Control 0xce: +/9/11   [???] -->
+		<!-- Control 0xcf: +/9/11   [???] -->
+		<!-- Control 0xd0: +/9/11   [???] -->
+		<!-- Control 0xd1: +/9/11   [???] -->
+		<!-- Control 0xd2: +/9/11   [???] -->
+		<!-- Control 0xd3: +/9/11   [???] -->
+		<!-- Control 0xd4: +/9/11   [???] -->
+		<!-- Control 0xd5: +/9/11   [???] -->
+		<!-- Control 0xfc: +/157/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/LEN1144.xml
+++ b/db/monitor/LEN1144.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/48 -->
+<monitor name="Lenovo ThinkVision LT2452P" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 18 1A 20 3E 6C 6E))" remove="(vcp(00 02 04 05 06 08 10 12 16 1C 1E 22 24 26 28 30 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/50/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x20: +/50/100 C [Horizontal Position] -->
+		<!-- Control 0x3e: +/69/100 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x6c: +/16/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/16/100 C [Green minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/42/7169 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0xac: +/9464/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/20554/65535 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/5/0 C [???] -->
+		<!-- Control 0xc9: +/256/0 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/3/10 C [???] -->
+		<!-- Control 0xe0: +/0/1   [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf2: +/1/1   [???] -->
+		<!-- Control 0xf3: +/8981/65535   [???] -->
+		<!-- Control 0xfa: +/41108/65535   [???] -->
+		<!-- Control 0xfb: +/0/1   [???] -->
+		<!-- Control 0xfc: +/10/5   [???] -->
+		<!-- Control 0xff: +/41108/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/LEN60CD.xml
+++ b/db/monitor/LEN60CD.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/308 -->
+<monitor name="Lenovo LEN T2254A" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/66/100 C [Brightness] -->
+		<!-- Control 0x12: +/72/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select (Main) - Digital] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/0/0 C [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x3e: +/100/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x54: +/0/255   [???] -->
+		<!-- Control 0x6b: +/0/255   [???] -->
+		<!-- Control 0x6c: +/0/255   [???] -->
+		<!-- Control 0x6e: +/0/255   [???] -->
+		<!-- Control 0x70: +/0/255   [???] -->
+		<!-- Control 0x77: +/0/1   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/64800/0 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/27349/65535 C [???] -->
+		<!-- Control 0xc6: +/169/255 C [???] -->
+		<!-- Control 0xc8: +/5/0 C [???] -->
+		<!-- Control 0xc9: +/256/0 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/30 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf2: +/1/1   [???] -->
+		<!-- Control 0xfa: +/54698/65535   [???] -->
+		<!-- Control 0xfb: +/0/1   [???] -->
+		<!-- Control 0xfc: +/10/5   [???] -->
+		<!-- Control 0xfe: +/65535/64768   [???] -->
+		<!-- Control 0xff: +/54698/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/LEN61A8.xml
+++ b/db/monitor/LEN61A8.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/30 -->
+<monitor name="Lenovo ThinkVision P27q-10" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/31/100 C [Brightness] -->
+		<!-- Control 0x12: +/85/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/18/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/1 C [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/3/4   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/257/65535   [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/LEN61DD.xml
+++ b/db/monitor/LEN61DD.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/245 -->
+<monitor name="Lenovo ThinkVision M14" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/100/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/19/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x86: +/2/5   [???] -->
+		<!-- Control 0x87: +/3/4   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/67/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/784/65535   [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdc: +/0/11   [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/0/2   [???] -->
+		<!-- Control 0xea: +/0/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/LEN61E9.xml
+++ b/db/monitor/LEN61E9.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/133 -->
+<monitor name="Lenovo P27h-20" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/60/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/5/14 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x86: +/2/5   [???] -->
+		<!-- Control 0x87: +/5/4   [???] -->
+		<!-- Control 0xac: +/23364/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/67/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/768/65535   [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/1/2   [???] -->
+		<!-- Control 0xea: +/0/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/MSI1462.xml
+++ b/db/monitor/MSI1462.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/185 -->
+<monitor name="MSI Optix MAG341CQ" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(16 18))" remove="(vcp(00 02 04 05 06 08 0E 10 12 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x16: +/52/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/48/100 C [Green maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0xac: +/17028/65282 C [???] -->
+		<!-- Control 0xae: +/10020/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/PHL0927.xml
+++ b/db/monitor/PHL0927.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/154 -->
+<monitor name="Philips Brilliance 328P" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 54 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/45/100 C [Brightness] -->
+		<!-- Control 0x12: +/51/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/93/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/84/100 C [Blue maximum level] -->
+		<!-- Control 0x54: +/0/1 C [Color temperature] -->
+		<!-- Control 0x62: +/80/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x14: +/6/11 C [Color Preset - 7500K] -->
+		<!-- Control 0x60: +/0/8206 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/5 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/45/85 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x72: +/160/251 C [???] -->
+		<!-- Control 0x86: +/8/8 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/64/1 C [???] -->
+		<!-- Control 0xae: +/2994/0 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc0: +/0/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/0/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/36 C [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdc: +/0/8 C [???] -->
+		<!-- Control 0xdf: +/768/255 C [???] -->
+		<!-- Control 0xe0: +/0/4 C [???] -->
+		<!-- Control 0xe9: +/0/2 C [???] -->
+		<!-- Control 0xeb: +/0/3 C [???] -->
+		<!-- Control 0xec: +/0/1027 C [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/1 C [???] -->
+		<!-- Control 0xf2: +/3/4   [???] -->
+		<!-- Control 0xf7: +/66/66 C [???] -->
+		<!-- Control 0xf9: +/0/4   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/PHL093F.xml
+++ b/db/monitor/PHL093F.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/193 -->
+<monitor name="Philips 346P1CRH" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 54 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/5/100 C [Brightness] -->
+		<!-- Control 0x12: +/25/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x54: +/0/1 C [Color Temperature Request] -->
+		<!-- Control 0x62: +/33/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/512/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/512/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/512/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/16/19 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/70/255 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/1 C [???] -->
+		<!-- Control 0x72: +/120/160 C [???] -->
+		<!-- Control 0x86: +/1/8 C [???] -->
+		<!-- Control 0x87: +/5/10 C [???] -->
+		<!-- Control 0xa5: +/0/512   [???] -->
+		<!-- Control 0xac: +/2/20128 C [???] -->
+		<!-- Control 0xae: +/10010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/36 C [???] -->
+		<!-- Control 0xdc: +/0/31 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe0: +/4/20   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xec: +/0/0   [???] -->
+		<!-- Control 0xf0: +/0/1 C [???] -->
+		<!-- Control 0xf9: +/0/4 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/PHLC249.xml
+++ b/db/monitor/PHLC249.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/200 -->
+<monitor name="Philips 329M1RV" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/80/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x14: +/5/11 C [Color Preset - 6500K] -->
+		<!-- Control 0x60: +/16/8206 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/5 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/35/85 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x72: +/120/251 C [???] -->
+		<!-- Control 0x86: +/8/8 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0x95: +/0/65535 C [???] -->
+		<!-- Control 0x96: +/0/65535 C [???] -->
+		<!-- Control 0x97: +/480/65535 C [???] -->
+		<!-- Control 0x98: +/270/65535 C [???] -->
+		<!-- Control 0xa4: +/0/65535   [???] -->
+		<!-- Control 0xa5: +/0/65535   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/2228/2 C [???] -->
+		<!-- Control 0xae: +/5999/0 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc0: +/1/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/256/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/36 C [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdc: +/0/4 C [???] -->
+		<!-- Control 0xdf: +/768/255 C [???] -->
+		<!-- Control 0xe0: +/0/4 C [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe7: +/50/100 C [???] -->
+		<!-- Control 0xe9: +/2/2 C [???] -->
+		<!-- Control 0xeb: +/0/3 C [???] -->
+		<!-- Control 0xec: +/0/1027 C [???] -->
+		<!-- Control 0xee: +/0/515 C [???] -->
+		<!-- Control 0xef: +/255/255 C [???] -->
+		<!-- Control 0xf0: +/0/1 C [???] -->
+		<!-- Control 0xf7: +/66/66 C [???] -->
+		<!-- Control 0xf9: +/0/4   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/PHLC284.xml
+++ b/db/monitor/PHLC284.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/257 -->
+<monitor name="Philips 34E1C5600HE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 54 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 56 58 60 62 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x54: +/1/1 C [Color Temperature Request] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x14: +/11/11 C [Color Preset - User 1] -->
+		<!-- Control 0x60: +/16/8206 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/100 C [???] -->
+		<!-- Control 0x0c: +/35/85 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x62: +/18/100   [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x72: +/160/251 C [???] -->
+		<!-- Control 0x86: +/8/8 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xa4: +/0/65535 C [???] -->
+		<!-- Control 0xa5: +/0/65535 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xaa: +/1/5   [???] -->
+		<!-- Control 0xac: +/46564/1 C [???] -->
+		<!-- Control 0xae: +/7513/0 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc0: +/1348/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/10/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/36 C [???] -->
+		<!-- Control 0xda: +/0/2   [???] -->
+		<!-- Control 0xdc: +/11/4 C [???] -->
+		<!-- Control 0xdf: +/768/255 C [???] -->
+		<!-- Control 0xe0: +/0/4 C [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe9: +/2/2 C [???] -->
+		<!-- Control 0xeb: +/0/3 C [???] -->
+		<!-- Control 0xec: +/0/1027 C [???] -->
+		<!-- Control 0xef: +/255/255 C [???] -->
+		<!-- Control 0xf0: +/0/1 C [???] -->
+		<!-- Control 0xf7: +/66/66 C [???] -->
+		<!-- Control 0xf9: +/0/4   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAC952D.xml
+++ b/db/monitor/SAC952D.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/326 -->
+<monitor name="Sentey MS-2405" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/18/100 C [Brightness] -->
+		<!-- Control 0x12: +/0/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0e: +/23168/100   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x3e: +/108/100   [???] -->
+		<!-- Control 0x52: +/108/100 C [???] -->
+		<!-- Control 0x62: +/70/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/2/4 C [???] -->
+		<!-- Control 0xac: +/2764/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/90/255 C [???] -->
+		<!-- Control 0xc8: +/9/0 C [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2 C [???] -->
+		<!-- Control 0xcc: +/13/13 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM05C5.xml
+++ b/db/monitor/SAM05C5.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/118 -->
+<monitor name="Samsung SyncMaster XL2370" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/62/100 C [Contrast] -->
+		<!-- Control 0x16: +/39/64 C [Red maximum level] -->
+		<!-- Control 0x18: +/39/64 C [Green maximum level] -->
+		<!-- Control 0x1a: +/39/64 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/5/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0e: +/80/160   [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/46/100   [???] -->
+		<!-- Control 0x30: +/24/40   [???] -->
+		<!-- Control 0x3e: +/17/31   [???] -->
+		<!-- Control 0x54: +/0/2   [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x87: +/15/25 C [???] -->
+		<!-- Control 0xaa: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/0 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/4/4 C [???] -->
+		<!-- Control 0xdc: +/6/7 C [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/0/515   [???] -->
+		<!-- Control 0xe1: +/1/1   [???] -->
+		<!-- Control 0xe2: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe8: +/0/7 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/0/4 C [???] -->
+		<!-- Control 0xeb: +/253/9 C [???] -->
+		<!-- Control 0xed: +/102/255   [???] -->
+		<!-- Control 0xee: +/104/255   [???] -->
+		<!-- Control 0xef: +/130/255   [???] -->
+		<!-- Control 0xf0: +/0/3 C [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/0/2 C [???] -->
+		<!-- Control 0xf5: +/2/2   [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM0737.xml
+++ b/db/monitor/SAM0737.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/52 -->
+<monitor name="Samsung 2333T" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/47/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/32/64 C [Red maximum level] -->
+		<!-- Control 0x18: +/32/64 C [Green maximum level] -->
+		<!-- Control 0x1a: +/32/64 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0e: +/80/160   [???] -->
+		<!-- Control 0x14: +/2/11 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/57/100   [???] -->
+		<!-- Control 0x30: +/19/40   [???] -->
+		<!-- Control 0x3e: +/30/31   [???] -->
+		<!-- Control 0x54: +/0/2   [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x87: +/25/25 C [???] -->
+		<!-- Control 0xaa: +/0/3   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/0 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/11   [???] -->
+		<!-- Control 0xdb: +/4/4 C [???] -->
+		<!-- Control 0xdc: +/2/7 C [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/3/515   [???] -->
+		<!-- Control 0xe1: +/1/1   [???] -->
+		<!-- Control 0xe2: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe8: +/0/7 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/0/4 C [???] -->
+		<!-- Control 0xeb: +/253/9 C [???] -->
+		<!-- Control 0xed: +/90/255   [???] -->
+		<!-- Control 0xee: +/94/255   [???] -->
+		<!-- Control 0xef: +/96/255   [???] -->
+		<!-- Control 0xf0: +/0/3 C [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/2/2 C [???] -->
+		<!-- Control 0xf5: +/2/2   [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM0794.xml
+++ b/db/monitor/SAM0794.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/47 -->
+<monitor name="Samsung SyncMaster SA300" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/80/160 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/255/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/2 C [Automatically adjust] -->
+		<!-- Control 0x20: +/69/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/17/40 C [Vertical Position] -->
+		<!-- Control 0x3e: +/2/31 C [Image Lock Fine (Clock Phase)] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/1/3 C [Input Source Select - Analog] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/255   [???] -->
+		<!-- Control 0x14: +/2/11 C [???] -->
+		<!-- Control 0x54: +/0/2   [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x87: +/15/25 C [???] -->
+		<!-- Control 0xaa: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/0 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/4/4 C [???] -->
+		<!-- Control 0xdc: +/255/5 C [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/3/517   [???] -->
+		<!-- Control 0xe1: +/1/1   [???] -->
+		<!-- Control 0xe2: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe8: +/10/7 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/0/4   [???] -->
+		<!-- Control 0xeb: +/253/9   [???] -->
+		<!-- Control 0xec: +/0/7 C [???] -->
+		<!-- Control 0xed: +/149/255   [???] -->
+		<!-- Control 0xee: +/145/255   [???] -->
+		<!-- Control 0xef: +/149/255   [???] -->
+		<!-- Control 0xf0: +/0/3 C [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/1/2   [???] -->
+		<!-- Control 0xf5: +/0/2   [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xf7: +/3/3 C [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM08CC.xml
+++ b/db/monitor/SAM08CC.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/53 -->
+<monitor name="Samsung SyncMaster S24B300" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/5/3 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/2/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0e: +/80/160   [???] -->
+		<!-- Control 0x14: +/2/11 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/63/100   [???] -->
+		<!-- Control 0x30: +/17/40   [???] -->
+		<!-- Control 0x3e: +/1/31   [???] -->
+		<!-- Control 0x54: +/0/2   [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x87: +/15/25 C [???] -->
+		<!-- Control 0xaa: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/0 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/4/4 C [???] -->
+		<!-- Control 0xdc: +/6/5 C [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/2/517   [???] -->
+		<!-- Control 0xe1: +/1/1   [???] -->
+		<!-- Control 0xe2: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe8: +/0/7 C [???] -->
+		<!-- Control 0xe9: +/0/1 C [???] -->
+		<!-- Control 0xea: +/0/4   [???] -->
+		<!-- Control 0xeb: +/253/9 C [???] -->
+		<!-- Control 0xec: +/0/7   [???] -->
+		<!-- Control 0xed: +/118/255   [???] -->
+		<!-- Control 0xee: +/118/255   [???] -->
+		<!-- Control 0xef: +/111/255   [???] -->
+		<!-- Control 0xf0: +/0/3 C [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/1/2   [???] -->
+		<!-- Control 0xf5: +/0/2   [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xf7: +/0/3 C [???] -->
+		<!-- Control 0xfe: +/1/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM0C86.xml
+++ b/db/monitor/SAM0C86.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/85 -->
+<monitor name="Samsung Syncmaster S24E650" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/60/100 C [Brightness] -->
+		<!-- Control 0x12: +/60/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/3/3 C [Input Source Select - Digital] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/255   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0e: +/0/160   [???] -->
+		<!-- Control 0x14: +/2/11 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/60   [???] -->
+		<!-- Control 0x3e: +/0/31   [???] -->
+		<!-- Control 0x54: +/0/2   [???] -->
+		<!-- Control 0x62: +/50/100   [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0x87: +/15/25 C [???] -->
+		<!-- Control 0xaa: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/0 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/4/30   [???] -->
+		<!-- Control 0xdb: +/4/4 C [???] -->
+		<!-- Control 0xdc: +/6/4 C [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/2/517   [???] -->
+		<!-- Control 0xe1: +/1/1   [???] -->
+		<!-- Control 0xe2: +/0/1   [???] -->
+		<!-- Control 0xe4: +/0/2   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe8: +/0/7   [???] -->
+		<!-- Control 0xe9: +/0/1   [???] -->
+		<!-- Control 0xea: +/0/4   [???] -->
+		<!-- Control 0xeb: +/253/9 C [???] -->
+		<!-- Control 0xec: +/0/7 C [???] -->
+		<!-- Control 0xed: +/124/255   [???] -->
+		<!-- Control 0xee: +/124/255   [???] -->
+		<!-- Control 0xef: +/125/255   [???] -->
+		<!-- Control 0xf0: +/0/3   [???] -->
+		<!-- Control 0xf2: +/0/2 C [???] -->
+		<!-- Control 0xf3: +/0/2 C [???] -->
+		<!-- Control 0xf5: +/0/2   [???] -->
+		<!-- Control 0xf6: +/1/2 C [???] -->
+		<!-- Control 0xf7: +/0/3 C [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM0D84.xml
+++ b/db/monitor/SAM0D84.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/84 -->
+<monitor name="Samsung PM49H" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(0E 10 12 16 18 1A 1E 20 30 3E 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 1C 22 24 26 28 32 38 3A 3C 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x0e: +/96/100 C [Image Lock Coarse (Clock)] -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/70/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/70/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/70/100 C [Blue maximum level] -->
+		<!-- Control 0x1e: +/0/1 C [Automatically adjust] -->
+		<!-- Control 0x20: +/116/100 C [Horizontal Position] -->
+		<!-- Control 0x30: +/0/100 C [Vertical Position] -->
+		<!-- Control 0x3e: +/0/100 C [Image Lock Fine (Clock Phase)] -->
+		<!-- Control 0x62: +/30/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/255/255 C [Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x06: +/0/1 C [Restore Factory Default Geometry] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xca: +/2/2 C [On Screen Display - Enable] -->
+		<!-- Control 0xcc: +/2/255 C [Language select - English] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xdc: +/2/3 C [Magic Bright Mode - Internet] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/70/170 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1f: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/255   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/0/65280 C [???] -->
+		<!-- Control 0xae: +/0/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xc0: +/106/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/545/65535 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xff: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM1016.xml
+++ b/db/monitor/SAM1016.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/189 -->
+<monitor name="Samsung UR55 UHD 4K (LU28R550UQEXXT)" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12))" remove="(vcp(00 02 04 05 06 08 0E 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/255 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/40/170 C [???] -->
+		<!-- Control 0x14: +/4/11 C [???] -->
+		<!-- Control 0x16: +/70/100   [???] -->
+		<!-- Control 0x18: +/70/100   [???] -->
+		<!-- Control 0x1a: +/70/100   [???] -->
+		<!-- Control 0x52: +/0/255   [???] -->
+		<!-- Control 0x60: +/15/3   [???] -->
+		<!-- Control 0x62: +/18/100   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/2   [???] -->
+		<!-- Control 0xaa: +/0/3   [???] -->
+		<!-- Control 0xac: +/2228/65282   [???] -->
+		<!-- Control 0xae: +/6010/65535   [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/4   [???] -->
+		<!-- Control 0xc0: +/36/65535   [???] -->
+		<!-- Control 0xc6: +/111/65535   [???] -->
+		<!-- Control 0xc8: +/18/65535   [???] -->
+		<!-- Control 0xc9: +/544/65535   [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xd6: +/1/4   [???] -->
+		<!-- Control 0xdc: +/2/3   [???] -->
+		<!-- Control 0xdf: +/513/65535   [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+		<!-- Control 0xff: +/0/1   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/SAM7058.xml
+++ b/db/monitor/SAM7058.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/217 -->
+<monitor name="Samsung LC32G75TQSMXUE" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x08: +/0/0 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/10/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/3 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/0/255 C [DPMS Control] -->
+		<!-- Control 0xdc: +/24/3 C [Magic Bright Mode] -->
+		<!-- Control 0xe1: +/2/5 C [Power control] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/2/5 C [???] -->
+		<!-- Control 0x20: +/0/255   [???] -->
+		<!-- Control 0x30: +/0/255   [???] -->
+		<!-- Control 0x87: +/15/100   [???] -->
+		<!-- Control 0xb0: +/0/255   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/1 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/0/255   [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/2/5   [???] -->
+		<!-- Control 0xe2: +/2/5   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xf3: +/0/2   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf7: +/2/3   [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSC0C28.xml
+++ b/db/monitor/VSC0C28.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/222 -->
+<monitor name="ViewSonic VX2453" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/33/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/66/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/80/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/80/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/80/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/0 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0e: +/85/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/120/100   [???] -->
+		<!-- Control 0x30: +/124/100   [???] -->
+		<!-- Control 0x3e: +/161/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x87: +/2/4 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/255/65535 C [???] -->
+		<!-- Control 0xc8: +/33545/36 C [???] -->
+		<!-- Control 0xc9: +/512/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/22 C [???] -->
+		<!-- Control 0xdf: +/512/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSC3236.xml
+++ b/db/monitor/VSC3236.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/316 -->
+<monitor name="ViewSonic VS17295" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/255/255 C [New Control Value] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/70/126 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x87: +/50/100 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xaa: +/1/65535   [???] -->
+		<!-- Control 0xac: +/1964/65281 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xc0: +/347/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xc9: +/3/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/255 C [???] -->
+		<!-- Control 0xdc: +/4/10   [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe6: +/1/1   [???] -->
+		<!-- Control 0xf0: +/0/1 C [???] -->
+		<!-- Control 0xfe: +/0/255   [???] -->
+		<!-- Control 0xff: +/0/1 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSC613B.xml
+++ b/db/monitor/VSC613B.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/267 -->
+<monitor name="ViewSonic vx3418" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/75/100 C [Brightness] -->
+		<!-- Control 0x12: +/70/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x60: +/15/19 C [Input Source Select (Main)] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/1/2   [???] -->
+		<!-- Control 0x05: +/0/1   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x08: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/0/1   [???] -->
+		<!-- Control 0x30: +/0/1   [???] -->
+		<!-- Control 0x52: +/0/1   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x72: +/120/160   [???] -->
+		<!-- Control 0x86: +/8/8   [???] -->
+		<!-- Control 0x87: +/2/4   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/3/19492   [???] -->
+		<!-- Control 0xae: +/14410/65535   [???] -->
+		<!-- Control 0xb2: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5   [???] -->
+		<!-- Control 0xc6: +/90/255   [???] -->
+		<!-- Control 0xc8: +/9/0   [???] -->
+		<!-- Control 0xc9: +/1/65535   [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/36 C [???] -->
+		<!-- Control 0xd6: +/1/5   [???] -->
+		<!-- Control 0xdc: +/1/31   [???] -->
+		<!-- Control 0xdf: +/514/65535   [???] -->
+		<!-- Control 0xe0: +/5/10   [???] -->
+		<!-- Control 0xe1: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xf1: +/1/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSC7E22.xml
+++ b/db/monitor/VSC7E22.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/82 -->
+<monitor name="ViewSonic VX2265wm" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps remove="(vcp(00 02 04 05 06 08 0E 10 12 16 18 1A 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- No controls were explicitly named by the issue scan. -->
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x02: +/70/2   [???] -->
+		<!-- Control 0x10: +/100/100   [???] -->
+		<!-- Control 0x62: +/24/100   [???] -->
+		<!-- Control 0x8d: +/2/2   [???] -->
+		<!-- Control 0xdf: +/512/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSCBC3B.xml
+++ b/db/monitor/VSCBC3B.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/255 -->
+<monitor name="ViewSonic VX2578-HD-PRO" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/20/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/49/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/49/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/49/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/255 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/1/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x68: +/13/5   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/4556/4 C [???] -->
+		<!-- Control 0xae: +/23962/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/6388/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/0/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/99/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/VSCE02C.xml
+++ b/db/monitor/VSCE02C.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/28 -->
+<monitor name="ViewSonic VX2270Smh-LED" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/65/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/80/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/80/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/80/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/4/4 C [Input Source Select] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/1 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0 C [???] -->
+		<!-- Control 0x0c: +/35/63 C [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/100/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/100/100   [???] -->
+		<!-- Control 0x52: +/16/255 C [???] -->
+		<!-- Control 0x87: +/4/4 C [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/2064/1 C [???] -->
+		<!-- Control 0xae: +/6010/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc6: +/255/65535 C [???] -->
+		<!-- Control 0xc8: +/33545/36 C [???] -->
+		<!-- Control 0xc9: +/1024/65535 C [???] -->
+		<!-- Control 0xca: +/2/2 C [???] -->
+		<!-- Control 0xcc: +/2/22 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>

--- a/db/monitor/WAC1064.xml
+++ b/db/monitor/WAC1064.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/122 -->
+<monitor name="Wacom Cintiq 16" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 10 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/128/255 C [Red maximum level] -->
+		<!-- Control 0x18: +/128/255 C [Green maximum level] -->
+		<!-- Control 0x1a: +/128/255 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+		<!-- Control 0xe1: +/0/2 C [Power control - Off] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x10: +/50/100   [???] -->
+		<!-- Control 0x13: +/75/100 C [???] -->
+		<!-- Control 0x14: +/5/11 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x20: +/50/100   [???] -->
+		<!-- Control 0x30: +/50/100   [???] -->
+		<!-- Control 0x52: +/50/100   [???] -->
+		<!-- Control 0x60: +/15/3   [???] -->
+		<!-- Control 0x63: +/0/100   [???] -->
+		<!-- Control 0x6c: +/80/100   [???] -->
+		<!-- Control 0x6e: +/80/100   [???] -->
+		<!-- Control 0x70: +/80/100   [???] -->
+		<!-- Control 0x87: +/2/4   [???] -->
+		<!-- Control 0x9b: +/120/255   [???] -->
+		<!-- Control 0x9d: +/110/255   [???] -->
+		<!-- Control 0x9f: +/128/255   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/65535 C [???] -->
+		<!-- Control 0xb2: +/2/2 C [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xb7: +/95/255   [???] -->
+		<!-- Control 0xb8: +/97/255   [???] -->
+		<!-- Control 0xb9: +/128/255   [???] -->
+		<!-- Control 0xba: +/120/255   [???] -->
+		<!-- Control 0xbb: +/110/255   [???] -->
+		<!-- Control 0xbc: +/128/255   [???] -->
+		<!-- Control 0xbd: +/128/255   [???] -->
+		<!-- Control 0xbe: +/105/255   [???] -->
+		<!-- Control 0xbf: +/112/255   [???] -->
+		<!-- Control 0xc1: +/1/65535   [???] -->
+		<!-- Control 0xc2: +/1/65535   [???] -->
+		<!-- Control 0xc3: +/4/65535   [???] -->
+		<!-- Control 0xc4: +/57/65535   [???] -->
+		<!-- Control 0xc6: +/90/255   [???] -->
+		<!-- Control 0xc8: +/25609/16 C [???] -->
+		<!-- Control 0xc9: +/256/1 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/38 C [???] -->
+		<!-- Control 0xdf: +/514/65535 C [???] -->
+		<!-- Control 0xe2: +/1/3 C [???] -->
+		<!-- Control 0xe6: +/113/255   [???] -->
+		<!-- Control 0xe7: +/107/255   [???] -->
+		<!-- Control 0xe8: +/118/255   [???] -->
+		<!-- Control 0xe9: +/107/255   [???] -->
+		<!-- Control 0xeb: +/1/65535   [???] -->
+		<!-- Control 0xec: +/0/255   [???] -->
+		<!-- Control 0xed: +/0/2   [???] -->
+		<!-- Control 0xef: +/2/3 C [???] -->
+		<!-- Control 0xf3: +/1/1   [???] -->
+		<!-- Control 0xf4: +/27/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

This audits all 147 open issues and adds 101 monitor XML profiles covering 105 issues that are solely requests for monitor support.

The profiles are intentionally conservative:

- only explicitly named, non-destructive controls from issue-provided scans are enabled;
- controls reported as `???` remain present but commented out for future investigation;
- factory-reset, input-source, power, and other value-sensitive controls remain disabled unless safely established;
- candidate mappings borrowed from similar profiles remain commented and clearly marked as unverified;
- every profile includes the VESA base profile and removes VESA controls that the corresponding scan did not explicitly confirm.

Hardware verification is requested from the issue authors before enabling additional controls or monitor-specific enum mappings.

## Validation

- `xmllint --noout` on all 101 new profiles
- `ddccontrol -b db -v -v -i <PNP_ID>` on all 101 new profiles
- `make check`
- `git diff --check`

## Issues covered by new profiles

Fixes ddccontrol/ddccontrol-db#2
Fixes ddccontrol/ddccontrol-db#11
Fixes ddccontrol/ddccontrol-db#12
Fixes ddccontrol/ddccontrol-db#14
Fixes ddccontrol/ddccontrol-db#15
Fixes ddccontrol/ddccontrol-db#16
Fixes ddccontrol/ddccontrol-db#17
Fixes ddccontrol/ddccontrol-db#18
Fixes ddccontrol/ddccontrol-db#19
Fixes ddccontrol/ddccontrol-db#28
Fixes ddccontrol/ddccontrol-db#30
Fixes ddccontrol/ddccontrol-db#31
Fixes ddccontrol/ddccontrol-db#32
Fixes ddccontrol/ddccontrol-db#37
Fixes ddccontrol/ddccontrol-db#38
Fixes ddccontrol/ddccontrol-db#39
Fixes ddccontrol/ddccontrol-db#44
Fixes ddccontrol/ddccontrol-db#47
Fixes ddccontrol/ddccontrol-db#48
Fixes ddccontrol/ddccontrol-db#51
Fixes ddccontrol/ddccontrol-db#52
Fixes ddccontrol/ddccontrol-db#53
Fixes ddccontrol/ddccontrol-db#57
Fixes ddccontrol/ddccontrol-db#60
Fixes ddccontrol/ddccontrol-db#62
Fixes ddccontrol/ddccontrol-db#63
Fixes ddccontrol/ddccontrol-db#64
Fixes ddccontrol/ddccontrol-db#68
Fixes ddccontrol/ddccontrol-db#73
Fixes ddccontrol/ddccontrol-db#76
Fixes ddccontrol/ddccontrol-db#79
Fixes ddccontrol/ddccontrol-db#82
Fixes ddccontrol/ddccontrol-db#84
Fixes ddccontrol/ddccontrol-db#85
Fixes ddccontrol/ddccontrol-db#86
Fixes ddccontrol/ddccontrol-db#88
Fixes ddccontrol/ddccontrol-db#89
Fixes ddccontrol/ddccontrol-db#91
Fixes ddccontrol/ddccontrol-db#95
Fixes ddccontrol/ddccontrol-db#97
Fixes ddccontrol/ddccontrol-db#99
Fixes ddccontrol/ddccontrol-db#100
Fixes ddccontrol/ddccontrol-db#105
Fixes ddccontrol/ddccontrol-db#106
Fixes ddccontrol/ddccontrol-db#112
Fixes ddccontrol/ddccontrol-db#118
Fixes ddccontrol/ddccontrol-db#119
Fixes ddccontrol/ddccontrol-db#122
Fixes ddccontrol/ddccontrol-db#133
Fixes ddccontrol/ddccontrol-db#138
Fixes ddccontrol/ddccontrol-db#146
Fixes ddccontrol/ddccontrol-db#148
Fixes ddccontrol/ddccontrol-db#149
Fixes ddccontrol/ddccontrol-db#151
Fixes ddccontrol/ddccontrol-db#154
Fixes ddccontrol/ddccontrol-db#159
Fixes ddccontrol/ddccontrol-db#171
Fixes ddccontrol/ddccontrol-db#175
Fixes ddccontrol/ddccontrol-db#185
Fixes ddccontrol/ddccontrol-db#189
Fixes ddccontrol/ddccontrol-db#191
Fixes ddccontrol/ddccontrol-db#193
Fixes ddccontrol/ddccontrol-db#194
Fixes ddccontrol/ddccontrol-db#199
Fixes ddccontrol/ddccontrol-db#200
Fixes ddccontrol/ddccontrol-db#206
Fixes ddccontrol/ddccontrol-db#213
Fixes ddccontrol/ddccontrol-db#217
Fixes ddccontrol/ddccontrol-db#220
Fixes ddccontrol/ddccontrol-db#222
Fixes ddccontrol/ddccontrol-db#223
Fixes ddccontrol/ddccontrol-db#224
Fixes ddccontrol/ddccontrol-db#225
Fixes ddccontrol/ddccontrol-db#230
Fixes ddccontrol/ddccontrol-db#234
Fixes ddccontrol/ddccontrol-db#239
Fixes ddccontrol/ddccontrol-db#241
Fixes ddccontrol/ddccontrol-db#244
Fixes ddccontrol/ddccontrol-db#245
Fixes ddccontrol/ddccontrol-db#253
Fixes ddccontrol/ddccontrol-db#255
Fixes ddccontrol/ddccontrol-db#257
Fixes ddccontrol/ddccontrol-db#259
Fixes ddccontrol/ddccontrol-db#260
Fixes ddccontrol/ddccontrol-db#262
Fixes ddccontrol/ddccontrol-db#264
Fixes ddccontrol/ddccontrol-db#267
Fixes ddccontrol/ddccontrol-db#270
Fixes ddccontrol/ddccontrol-db#302
Fixes ddccontrol/ddccontrol-db#304
Fixes ddccontrol/ddccontrol-db#305
Fixes ddccontrol/ddccontrol-db#306
Fixes ddccontrol/ddccontrol-db#307
Fixes ddccontrol/ddccontrol-db#308
Fixes ddccontrol/ddccontrol-db#310
Fixes ddccontrol/ddccontrol-db#312
Fixes ddccontrol/ddccontrol-db#314
Fixes ddccontrol/ddccontrol-db#316
Fixes ddccontrol/ddccontrol-db#317
Fixes ddccontrol/ddccontrol-db#318
Fixes ddccontrol/ddccontrol-db#319
Fixes ddccontrol/ddccontrol-db#321
Fixes ddccontrol/ddccontrol-db#323
Fixes ddccontrol/ddccontrol-db#324
Fixes ddccontrol/ddccontrol-db#326

## Relevant issues already supported on master

No new profile was needed for ddccontrol/ddccontrol-db#29, ddccontrol/ddccontrol-db#42, ddccontrol/ddccontrol-db#45, ddccontrol/ddccontrol-db#59, ddccontrol/ddccontrol-db#61, ddccontrol/ddccontrol-db#69, ddccontrol/ddccontrol-db#80, ddccontrol/ddccontrol-db#81, ddccontrol/ddccontrol-db#93, ddccontrol/ddccontrol-db#108, ddccontrol/ddccontrol-db#110, ddccontrol/ddccontrol-db#147, ddccontrol/ddccontrol-db#152, ddccontrol/ddccontrol-db#170, ddccontrol/ddccontrol-db#180, ddccontrol/ddccontrol-db#215, ddccontrol/ddccontrol-db#218, ddccontrol/ddccontrol-db#247, ddccontrol/ddccontrol-db#261, ddccontrol/ddccontrol-db#303, ddccontrol/ddccontrol-db#315, ddccontrol/ddccontrol-db#320, ddccontrol/ddccontrol-db#322, and ddccontrol/ddccontrol-db#325.

## Support requests needing more information

No profile was added for ddccontrol/ddccontrol-db#8, ddccontrol/ddccontrol-db#10, ddccontrol/ddccontrol-db#121, ddccontrol/ddccontrol-db#168, or ddccontrol/ddccontrol-db#254 because the issue does not provide a usable monitor PNP ID. Guessing those IDs would risk matching the wrong hardware.

## Issues excluded from the monitor-profile batch

ddccontrol/ddccontrol-db#27, ddccontrol/ddccontrol-db#36, ddccontrol/ddccontrol-db#43, ddccontrol/ddccontrol-db#123, ddccontrol/ddccontrol-db#134, ddccontrol/ddccontrol-db#157, ddccontrol/ddccontrol#307, ddccontrol/ddccontrol-db#174, ddccontrol/ddccontrol-db#181, ddccontrol/ddccontrol-db#187, ddccontrol/ddccontrol-db#212, ddccontrol/ddccontrol-db#311, and ddccontrol/ddccontrol#309 concern driver/transport failures, database-wide behavior, usage questions, or other bugs rather than solely requesting a monitor profile.
