### PR TITLE
feat: catalog monitors sharing PNP IDs

### DIFF
--- a/db/monitor/AOC2402.xml
+++ b/db/monitor/AOC2402.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
-<monitor name="AOC 24G2" init="standard">
+<!--
+https://github.com/ddccontrol/ddccontrol-db/issues/180
+
+AOC reuses PNP ID AOC2402 for the 24G2 and 24B2XDAM. The monitor-specific
+mappings below were verified on the 24G2 and are unverified candidate
+mappings for the 24B2XDAM.
+-->
+<monitor name="AOC 24G2 / 24B2XDAM" init="standard">
 	<caps add="(prot(monitor)type(LCD)model(24G2U)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 0C 10 12 14(01 05 06 08 0B) 16 18 1A 52 60(01 0F 11 12 ) 86(01 02 05 0B 0C 0D 0E 0F 10 11)  AC AE B2 B6 C6 C8 CA CC(01 02 03 04 05 06 07 09 0A 0B 0D 0E 12 14 16 1E) D6(01 04 05) DC(00 0B 0C 0D 0E 0F 10) DF ED FF)mswhql(1)asset_eep(40)mccs_ver(2.2))" />
 	<controls>
 		<control id="brightness" address="0x10"/>

--- a/db/monitor/DELA0A4.xml
+++ b/db/monitor/DELA0A4.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
-<!-- No DDC over DP and mDP. No control from HDMI1 when HDMI2 is displayed and vice versa.
+<!--
+Reports:
+https://github.com/ddccontrol/ddccontrol-db/issues/10
+https://github.com/ddccontrol/ddccontrol-db/issues/59
+
+The scans in issue #10 have identical capabilities and controls. Their
+different current values reflect monitor settings, not separate profiles.
+
+No DDC over DP and mDP. No control from HDMI1 when HDMI2 is displayed and vice versa.
 Identifies as DELA0B2 on HDMI-2 input.
 -->
 <monitor name="Dell U2414H (HDMI 1)" init="standard">

--- a/db/monitor/GSM59F1.xml
+++ b/db/monitor/GSM59F1.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0"?>
-<monitor name="LG 25UM58" init="standard">
+<!--
+https://github.com/ddccontrol/ddccontrol-db/issues/45
+
+LG reuses PNP ID GSM59F1 for the 25UM58 and 25UM65. The pre-existing
+monitor-specific mappings below were added for the 25UM58 and are unverified
+candidate mappings for the 25UM65.
+-->
+<monitor name="LG 25UM58 / 25UM65" init="standard">
 <caps add="(vcp(02030405080B0C101214(01 05 06 07 08 0B)1516181A4D4E4F5260(01 03 04)626C6E70878DACAEB6C0C6C8C9D6(01 04)DFE0E1E3(00 01 02 03 04 10 11 12 13 14)ECEFFD(00 01)FE(00 01 02)F4F5F6F7F8F9FF)mswhql(1)mccs_ver(2.1))"/>
 
 	<controls>
-    <!-- GET from GSM5B09 (LG 27UD68p) -->)
+    <!-- Copied from GSM5B09 (LG 27UD68P); unverified candidate mappings. -->
     <control id="inputsource" type="list" address="0x60">
 		<value id="hdmi1" name="hd" value="0x11"/>
 		<value id="hdmi2" value="0x12"/>
@@ -45,5 +52,4 @@
     <!--<include file="VESA"/>-->
     <include file="GSMlcd"/>
 </monitor>
-
 

--- a/db/monitor/GSM5B09.xml
+++ b/db/monitor/GSM5B09.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0"?>
-<monitor name="LG 27UD68P" init="standard">
+<!--
+Reports:
+https://github.com/ddccontrol/ddccontrol-db/issues/69
+https://github.com/ddccontrol/ddccontrol-db/issues/80
+https://github.com/ddccontrol/ddccontrol-db/issues/325
+
+LG reuses PNP ID GSM5B09 for several models. The monitor-specific mappings
+below were added for the 27UD68P and are unverified candidate mappings for
+the 27UD88, 27UD58, and 24UD58. In particular, input switching is reported
+as unreliable on the 27UD58 in issue #80.
+-->
+<monitor name="LG 27UD68P / 27UD88 / 27UD58 / 24UD58" init="standard">
 	<caps add="(vcp(04 08 10 12 14(05 08 0B ) 16 18 1A 60( 11 12 0F 10) D6(01 04) 62 8D F5(00 01 02) F6(00 01 02) 15(01 07 08 11 13 14 15 18 19 20 22 23 24 28 29) F7(00 01 02 03) F8(00 01)))" remove="(vcp(02 05 4D 4E 4F 52 AC AE B2 B6 C0 C6 C8 C9 DF F4 F9 FE(00 01 02) FD(00 01) FF))"/>
 	<controls>
 		<control id="inputsource" type="list" address="0x60">

--- a/db/monitor/GSM7706.xml
+++ b/db/monitor/GSM7706.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0"?>
-<monitor name="LG GSM770 HDMI" init="standard">
+<!--
+https://github.com/ddccontrol/ddccontrol-db/issues/81
+
+LG reuses PNP ID GSM7706 across models. The shared GSM770X mappings were
+verified on other LG GSM770 variants and are unverified candidates for the
+27UK850-W.
+-->
+<monitor name="LG 27UK850-W / GSM770 HDMI variants" init="standard">
 	<include file="GSM770X"/>
 </monitor>

--- a/db/monitor/GSM7707.xml
+++ b/db/monitor/GSM7707.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0"?>
-<monitor name="LG GSM770 Display Port" init="standard">
+<!--
+Reports:
+https://github.com/ddccontrol/ddccontrol-db/issues/93
+https://github.com/ddccontrol/ddccontrol-db/issues/315
+
+LG reuses PNP ID GSM7707 across models. The shared GSM770X mappings were
+verified on other LG GSM770 variants and are unverified candidates for the
+32UD99 and 27UN880-B.
+-->
+<monitor name="LG 32UD99 / 27UN880-B / GSM770 DisplayPort variants" init="standard">
 	<include file="GSM770X"/>
 </monitor>

--- a/db/monitor/GSM770X.xml
+++ b/db/monitor/GSM770X.xml
@@ -120,4 +120,5 @@
 			<value id="mode4" value="0x10"/>
 		</control>
 	</controls>
+	<include file="VESA"/>
 </monitor>

--- a/db/monitor/GSM7750.xml
+++ b/db/monitor/GSM7750.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
-<!-- This model number is for the DisplayPort-port of the "LG 32BN67UP-B". For HDMI-Ports the type is "GSM774F". -->
-<monitor name="LG 32BN67UP-B (DP)" init="standard">
+<!--
+https://github.com/ddccontrol/ddccontrol-db/issues/320
+
+LG reuses PNP ID GSM7750 for the DisplayPort input of the 32BN67UP-B and
+32UN880-B. The issue author explicitly verified brightness, contrast, RGB
+gain, and speaker volume on the 32UN880-B. Other monitor-specific mappings
+below were verified on the 32BN67UP-B and are unverified candidates for the
+32UN880-B. For HDMI ports, the 32BN67UP-B identifies as GSM774F.
+-->
+<monitor name="LG 32BN67UP-B / 32UN880-B (DP)" init="standard">
 	<!-- ioctl(): Inappropriate ioctl for device - Capabilities read fail. -->
 	<!-- Therefore this custom capabilities string was added -->
 	<caps add="(prot(monitor)type(lcd)model(GSM7750)vcp(04 05 08 10 12 15 16 18 1A 62 6C 6E 70 87 8D CC EB F5 F6 F7 F8 F9 FE))"/>
@@ -157,6 +165,7 @@
 		</control>
 
 	</controls>
+	<include file="VESA"/>
 </monitor>
 
 <!-- 


### PR DESCRIPTION
## Summary

- Catalog LG and AOC model variants that reuse existing PNP IDs, so the selected profile names explicitly identify the reported monitors.
- Document that the two scans in #10 have identical capabilities and controls; only current setting values differ.
- Add the required VESA include to the shared GSM770 profile and to GSM7750, covering the explicitly verified basic controls for the LG 32UN880-B from #320.

## Safety

The profiles remain intentionally conservative. No new monitor-specific enum mappings are enabled. Existing mappings are preserved for the models they were originally verified on and clearly labeled as unverified candidate mappings for sibling models sharing the PNP ID.

Hardware verification is requested from the issue authors before enabling additional controls or treating the existing model-specific mappings as verified on the sibling models. Issue #80 remains referenced rather than closed because its input-switching behavior is still unresolved.

## Validation

- `./configure --prefix=/usr`
- `make check`
- `make check-db`
- Individual `ddccontrol -b db -v -v -i PNP_ID` checks for all eight affected profiles
- `git diff --check`

Fixes #10
Fixes #45
Fixes #69
Refs #80
Fixes #81
Fixes #93
Fixes #180
Fixes #315
Fixes #320
Fixes #325
