### PR TITLE
feat: add conservative GSM5C34 monitor profile

### DIFF
--- a/db/monitor/GSM5C34.xml
+++ b/db/monitor/GSM5C34.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/378 -->
+<monitor name="LG Standard LCD" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		The scan selected /dev/i2c-9 (LG Standard LCD); the ASUS display
+		listed in the issue title was detected on /dev/i2c-8 but not scanned.
+		Do not expose reset-style controls until explicitly validated.
+	-->
+	<caps add="(type(lcd)vcp(02 10 12 16 18 1A 62 D6))" remove="(vcp(04 05 06 08 0E 1E 20 30 3E 60 6C 6E 70))"/>
+	<controls>
+		<!-- Known controls from issue output kept disabled due to destructive behavior risk. -->
+		<!-- Scan format reminder: +/current/max C [Description] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+
+		<!-- Control 0x60: +/15/18 C [Input Source Select (Main)] -->
+		<!-- Input source enum values were not explicitly confirmed in the issue output. -->
+		<!-- Keep 0x60 disabled until its monitor-specific mapping is hardware-verified. -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Some scan entries have inconsistent current/max values; kept verbatim and unverified. -->
+		<!-- Notable anomalies: 0x6c/0x6e/0x70, 0xac/0xae, 0xdf, 0xe9. -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/65502/65535 C [???] -->
+		<!-- Control 0x15: +/45/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x45: +/0/65535   [???] -->
+		<!-- Control 0x4d: +/32770/65535 C [???] -->
+		<!-- Control 0x4e: +/16396/65535 C [???] -->
+		<!-- Control 0x4f: +/7042/65535 C [???] -->
+		<!-- Control 0x50: +/2/15   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x55: +/0/1   [???] -->
+		<!-- Control 0x69: +/8300/65535   [???] -->
+		<!-- Control 0x6a: +/527/65535   [???] -->
+		<!-- Control 0x6c: +/128/100   [???] -->
+		<!-- Control 0x6e: +/128/100   [???] -->
+		<!-- Control 0x70: +/128/100   [???] -->
+		<!-- Control 0x72: +/25600/65535   [???] -->
+		<!-- Control 0x7a: +/240/65535   [???] -->
+		<!-- Control 0x83: +/512/15143   [???] -->
+		<!-- Control 0x85: +/0/255   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0xa1: +/37/65535   [???] -->
+		<!-- Control 0xac: +/59420/5 C [???] -->
+		<!-- Control 0xae: +/38710/0 C [???] -->
+		<!-- Control 0xaf: +/65280/255   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/2520/65535 C [???] -->
+		<!-- Control 0xc1: +/88/300   [???] -->
+		<!-- Control 0xc5: +/0/1   [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc8: +/21/255 C [???] -->
+		<!-- Control 0xc9: +/776/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/0/16   [???] -->
+		<!-- Control 0xcf: +/269/65535   [???] -->
+		<!-- Control 0xd7: +/1/255   [???] -->
+		<!-- Control 0xd8: +/1/255   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe2: +/1/65535   [???] -->
+		<!-- Control 0xe4: +/0/255 C [???] -->
+		<!-- Control 0xe5: +/0/179 C [???] -->
+		<!-- Control 0xe6: +/0/65535 C [???] -->
+		<!-- Control 0xe7: +/0/65535 C [???] -->
+		<!-- Control 0xe8: +/0/255 C [???] -->
+		<!-- Control 0xe9: +/4276/255 C [???] -->
+		<!-- Control 0xea: +/0/255 C [???] -->
+		<!-- Control 0xeb: +/0/1 C [???] -->
+		<!-- Control 0xec: +/1/255   [???] -->
+		<!-- Control 0xef: +/49184/65535 C [???] -->
+		<!-- Control 0xf2: +/0/255   [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/0/255 C [???] -->
+		<!-- Control 0xf7: +/255/255 C [???] -->
+		<!-- Control 0xf8: +/1/255 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+		<!-- Control 0xfa: +/255/255 C [???] -->
+		<!-- Control 0xfb: +/1/15   [???] -->
+		<!-- Control 0xfe: +/2/255 C [???] -->
+	</controls>
+	<!-- VESA include is safe: reset, input, and unverified codes (04 05 06 08 0E 1E 20 30 3E 60 6C 6E 70) are explicitly removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a dedicated `GSM5C34.xml` profile based on the issue-provided scan
- expose only explicitly named, low-risk controls through the standard VESA definitions
- include the required `VESA` profile

## Context

The report contains two detected monitors. The scan itself selected `/dev/i2c-9`, whose EDID identifies as PNP ID `GSM5C34` and monitor name `LG Standard LCD`; the ASUS TUF VG27AQ listed in the issue title was detected on `/dev/i2c-8` but was not scanned. The missing dedicated `GSM5C34` profile caused ddccontrol to fall back to a generic manufacturer profile after the capabilities read failed.

This change therefore targets only the PNP ID and control data actually present in the report. It does not claim verified ASUS TUF VG27AQ support.

## Safety

This profile is intentionally conservative. Factory-reset controls are disabled, every control reported as `???` remains commented out, and unverified candidate mappings are left commented out or disabled. In particular, input source control `0x60` is not exposed because the report does not confirm the monitor-specific enum values.

Hardware verification is requested from the issue author/reporter before enabling any additional controls or candidate mappings. A targeted scan of the ASUS display on `/dev/i2c-8` is also needed before adding a profile for that monitor.

## Validation

- `xmllint --noout db/monitor/GSM5C34.xml`
- `ddccontrol -b db -v -v -i GSM5C34`
- `./configure --prefix=/usr && make && make check`

Fixes #378
