### PR TITLE
feat: add ASUS PA248QV support

### DIFF
--- a/db/monitor/AUS2487.xml
+++ b/db/monitor/AUS2487.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/212 -->
+<monitor name="ASUS PA248QV" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/25/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/100/100 C [Audio Speaker Volume Adjust] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/2/2 C [New Control Value - Some values changed] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/17/18 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/5 C [DPMS Control - On] -->
+
+		<!--
+			Unverified input-source candidates from the issue capability values
+			and similar ASUS profiles. Keep disabled pending hardware verification.
+		-->
+		<!--
+		<control id="inputsource" type="list" address="0x60">
+			<value id="analog" value="0x01"/>
+			<value id="hdmi1" value="0x11"/>
+			<value id="dp" value="0x0f"/>
+		</control>
+		-->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x03: +/0/5   [???] -->
+		<!-- Control 0x06: +/0/1   [???] -->
+		<!-- Control 0x0b: +/100/0   [???] -->
+		<!-- Control 0x0c: +/35/63   [???] -->
+		<!-- Control 0x0e: +/0/100   [???] -->
+		<!-- Control 0x14: +/5/12 C [???] -->
+		<!-- Control 0x1e: +/0/1   [???] -->
+		<!-- Control 0x1f: +/1/1   [???] -->
+		<!-- Control 0x20: +/1/1   [???] -->
+		<!-- Control 0x30: +/1/1   [???] -->
+		<!-- Control 0x3e: +/1/1   [???] -->
+		<!-- Control 0x52: +/8/255 C [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x87: +/0/100   [???] -->
+		<!-- Control 0xac: +/28664/1 C [???] -->
+		<!-- Control 0xae: +/7510/65535 C [???] -->
+		<!-- Control 0xb2: +/1/1   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/3589/65535 C [???] -->
+		<!-- Control 0xc6: +/133/65535 C [???] -->
+		<!-- Control 0xc8: +/13833/37 C [???] -->
+		<!-- Control 0xc9: +/1/65535 C [???] -->
+		<!-- Control 0xca: +/1/2   [???] -->
+		<!-- Control 0xcc: +/2/13 C [???] -->
+		<!-- Control 0xdc: +/0/35 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xfd: +/98/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a monitor profile for the ASUS PA248QV using PNP ID `AUS2487`
- expose only explicitly named, non-destructive controls through the VESA include
- keep reset, input-source, and power controls disabled pending hardware verification
- preserve controls reported as `???` as comments for future investigation

The profile is intentionally conservative so it is safe to distribute without assuming monitor-specific semantics. Candidate input-source mappings are commented out and clearly marked as unverified.

Hardware verification is requested from the issue author before enabling additional controls or monitor-specific enum mappings.

Fixes #212

## Validation

- `xmllint --noout db/monitor/AUS2487.xml`
- `ddccontrol -b db -v -v -i AUS2487`
- `make check`
- `make check-db`
- `git diff --check`
