### PR TITLE
feat: document Dell U3219Q probe controls

### DIFF
--- a/db/monitor/DELA133.xml
+++ b/db/monitor/DELA133.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/170 -->
 <monitor name="Dell U3219Q" init="standard">
   <caps add="(prot(monitor)type(LCD)model(U3219Q)cmds(01 02 03 07 0C E3 F3)vcp(02 04 05 08 10 12 14(05 08 0B 0C) 16 18 1A 52 60(01 0F 11 ) AA(01 02 04 ) AC AE B2 B6 C6 C8 C9 CC(02 0A 03 04 08 09 0D 06 ) D6(01 04 05) DC(00 03 05 ) DF E0 E1 E2(00 1D 02 04 0E 12 14 ) F0(0C ) F1 F2 FD)mswhql(1)asset_eep(40)mccs_ver(2.1))"/>
     <controls>
@@ -14,6 +15,41 @@
       <control id="osdorientation" address="0xaa"/>
       <control id="dpms" address="0xd6"/>
       <control id="power" address="0xe1"/>
+
+      <!-- Probe notes from issue #170. Existing controls above are unchanged. -->
+      <!-- Control 0x14: +/73/100 C [???] -->
+      <!-- Control 0x52: +/16/255 C [???] -->
+      <!-- Control 0xac: +/2428/2 C [???] -->
+      <!-- Control 0xae: +/6010/65535 C [???] -->
+      <!-- Control 0xb2: +/1/1 C [???] -->
+      <!-- Control 0xb6: +/3/5 C [???] -->
+      <!-- Control 0xc6: +/17868/65535 C [???] -->
+      <!-- Control 0xc8: +/38665/39 C [???] -->
+      <!-- Control 0xc9: +/16644/65535 C [???] -->
+      <!-- Control 0xcc: +/2/13 C [???] -->
+      <!-- Control 0xdc: +/0/5 C [???] -->
+      <!-- Control 0xdf: +/513/65535 C [???] -->
+      <!-- Control 0xe0: +/0/1 C [???] -->
+      <!-- Control 0xe2: +/0/255 C [???] -->
+      <!-- Control 0xe4: +/0/2 C [???] -->
+      <!-- Control 0xe5: +/0/255 C [???] -->
+      <!-- Control 0xe7: +/2/63 C [???] -->
+      <!-- Control 0xe8: +/27/65535 C [???] -->
+      <!-- Control 0xe9: +/0/255 C [???] -->
+      <!-- Control 0xea: +/65025/65025 C [???] -->
+      <!-- Control 0xf0: +/0/255 C [???] -->
+      <!-- Control 0xf1: +/267/65535 C [???] -->
+      <!-- Control 0xf2: +/0/255 C [???] -->
+      <!-- Control 0xfd: +/98/255 C [???] -->
+
+      <!-- Unverified candidate mappings borrowed from the similar Dell P2720DC
+           profile (DELD0FB.xml); keep disabled until tested on this U3219Q.
+      <control id="inputsource" type="list" address="0x60">
+        <value id="dp" value="3855"/>
+        <value id="usb-c" value="3867"/>
+        <value id="hdmi" value="3857"/>
+      </control>
+      -->
     </controls>
     <include file="VESA"/>
 </monitor>


### PR DESCRIPTION
## Summary

- preserve every existing capability and active control in the `DELA133` Dell U3219Q profile unchanged
- add a header linking the profile to issue #170
- retain unknown advertised VCP controls from the probe as comments for future investigation
- document possible DisplayPort, USB-C, and HDMI mappings as commented, unverified candidates

## Compatibility and verification

This change is strictly additive: the existing profile behavior, reset controls, input source control, and VESA include are unchanged.

The candidate input mappings were borrowed from the similar Dell P2720DC profile and remain commented out. @hughrawlinson, hardware verification on the U3219Q is requested before enabling those candidates or any additional controls.

## Validation

- final diff against `master`: 36 additions, 0 deletions
- `xmllint --noout db/monitor/DELA133.xml`
- `ddccontrol -b db -v -v -i DELA133`
- `./configure --prefix=/usr`
- `make -j"$(nproc)"`
- `make check`

Fixes #170
