### PR TITLE
fix: make SAM0E16 profile conservative

### DIFF
--- a/db/monitor/SAM0E16.xml
+++ b/db/monitor/SAM0E16.xml
@@ -1,19 +1,67 @@
 <?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/322 -->
 <monitor name="Samsung C27HG70" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly identified, non-destructive level controls are enabled.
+	-->
+	<caps add="(prot(monitor)type(lcd)vcp(10 12 16 18 1A))"
+		remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
 	<controls>
-		<control id="defaultcolor" name="Restore Factory Default Color" address="0x08"/>
-		
-		<control id="brightness" name="Brightness" address="0x10"/>
-		<control id="contrast" name="Contrast" address="0x12"/>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/100/100 C [Brightness] -->
+		<!-- Control 0x12: +/75/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
 
-		<control id="inputsource" type="list" name="Input Source Select (main)" address="0x60">
-			<value id="hdmi1" name="HDMI 1" value="5"/>
-			<value id="hdmi2" name="HDMI 2" value="6"/>
-			<value id="dp" name="Display Port" value="9"/>
-		</control>
+		<!-- Known controls kept disabled until their behavior or values are verified on this hardware: -->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x08: +/0/0 C [Restore Factory Default Color] (destructive reset-style control) -->
+		<!-- Control 0x60: +/9/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xaa: +/1/3 C [OSD Orientation - Landscape] -->
+		<!-- Control 0xd6: +/0/255 C [DPMS Control] -->
+		<!-- Control 0xdc: +/24/3 C [Magic Bright Mode] -->
+		<!-- Control 0xe1: +/2/5 C [Power control] -->
 
-		<control id="red" name="Red maximum level" address="0x16"/>
-		<control id="green" name="Green maximum level" address="0x18"/>
-		<control id="blue" name="Blue maximum level" address="0x1A"/>
+		<!--
+			Unverified candidate input mappings carried over from the earlier
+			SAM0E16 definition in PR #246. Issue #322 does not confirm them,
+			so they must remain disabled pending hardware verification:
+
+			<control id="inputsource" type="list" address="0x60">
+				<value id="hdmi1" value="5"/>
+				<value id="hdmi2" value="6"/>
+				<value id="dp" value="9"/>
+			</control>
+		-->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/2/5 C [???] -->
+		<!-- Control 0x20: +/0/255   [???] -->
+		<!-- Control 0x30: +/0/255   [???] -->
+		<!-- Control 0x87: +/15/100   [???] -->
+		<!-- Control 0xb0: +/0/255   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/1 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/0/255   [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/2/5   [???] -->
+		<!-- Control 0xe2: +/2/5   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xf3: +/0/2   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf7: +/1/3   [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
+
+		<!-- Capability data also listed 0x04, 0x05, 0x52, 0xac, 0xae, 0xb2, and 0xfd without decoded control rows. -->
 	</controls>
+	<!-- VESA controls not explicitly identified as safe above are removed through caps. -->
+	<include file="VESA"/>
 </monitor>


### PR DESCRIPTION
## Summary

- update the existing `SAM0E16` profile for the Samsung C27HG70 / LC27HG7 report
- enable only the explicitly identified, non-destructive brightness, contrast, and RGB level controls through the VESA include
- keep every `???` control from the scan commented out for future investigation
- disable reset-style controls and unverified input, power, orientation, and picture-mode mappings

## Rationale

The PNP ID was already present from PR #246, but that profile exposed a factory color reset and input-source values that issue #322 does not confirm. This revision is intentionally conservative so it is safe to distribute in packages.

The earlier input-source values are retained only as commented, unverified candidate mappings. Hardware verification is requested from the issue author before those mappings or any additional controls are enabled.

## Validation

- `xmllint --noout db/monitor/SAM0E16.xml`
- `make check`
- `ddccontrol -b db -v -v -i SAM0E16`
- `git diff --check`

Fixes #322
