### PR TITLE
feat: document unknown SAM0E16 controls

### DIFF
--- a/db/monitor/SAM0E16.xml
+++ b/db/monitor/SAM0E16.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/322 -->
 <monitor name="Samsung C27HG70" init="standard">
 	<controls>
 		<control id="defaultcolor" name="Restore Factory Default Color" address="0x08"/>
@@ -15,5 +16,30 @@
 		<control id="red" name="Red maximum level" address="0x16"/>
 		<control id="green" name="Green maximum level" address="0x18"/>
 		<control id="blue" name="Blue maximum level" address="0x1A"/>
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/2/5 C [???] -->
+		<!-- Control 0x20: +/0/255   [???] -->
+		<!-- Control 0x30: +/0/255   [???] -->
+		<!-- Control 0x87: +/15/100   [???] -->
+		<!-- Control 0xb0: +/0/255   [???] -->
+		<!-- Control 0xb6: +/3/9 C [???] -->
+		<!-- Control 0xc6: +/1/1 C [???] -->
+		<!-- Control 0xc8: +/5/16 C [???] -->
+		<!-- Control 0xc9: +/1/1 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xdb: +/0/255   [???] -->
+		<!-- Control 0xdf: +/512/514 C [???] -->
+		<!-- Control 0xe0: +/2/5   [???] -->
+		<!-- Control 0xe2: +/2/5   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe9: +/0/255   [???] -->
+		<!-- Control 0xf3: +/0/2   [???] -->
+		<!-- Control 0xf5: +/0/255   [???] -->
+		<!-- Control 0xf7: +/1/3   [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
 	</controls>
+	<include file="VESA"/>
 </monitor>


### PR DESCRIPTION
## Summary

- preserve every existing `SAM0E16` control and value unchanged
- add the issue #322 reference
- add all controls reported as `???` as comments for future investigation
- include the required VESA profile

## Rationale

This is an intentionally conservative, additive-only update: the profile keeps its existing factory color, brightness, contrast, input-source, and RGB settings. No existing mappings are removed or changed.

Unknown controls and any future candidate mappings remain commented out. Hardware verification is requested from the issue author before enabling any additional controls.

## Validation

- final diff: `26 insertions, 0 deletions`
- `xmllint --noout db/monitor/SAM0E16.xml`
- `make check`
- `ddccontrol -b db -v -v -i SAM0E16`
- `git diff origin/master --check`

Fixes #322
