### PR TITLE
fix: keep SAM7476 update additive-only

### DIFF
--- a/db/monitor/SAM7476.xml
+++ b/db/monitor/SAM7476.xml
@@ -1,65 +1,79 @@
 <?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/261 -->
 <monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA" init="standard">
-	<caps add="(vcp(2F DB(0 1 2 3 4 5 6 7 8 9)))" />
-	<include file="SAM7119" />
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Infinity Core Lighting is not exposed by the monitor over DDC.
+	-->
+	<caps add="(type(lcd)vcp(02 10 12 16 18 1A 62))" remove="(vcp(00 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
 	<controls>
-		<control id="screensize" address="0xdb">
-			<value id="auto" value="0" />
-			<value id="wide" value="1" />
-			<value id="17_4_3" value="2" />
-			<value id="19_4_3" value="3" />
-			<value id="19_wide_16_10" value="4" />
-			<value id="21_5_wide_16_9" value="5" />
-			<value id="22_wide_16_10" value="6" />
-			<value id="23_wide_16_9" value="7" />
-			<value id="27_wide_16_9" value="8" />
-			<value id="29_wide_21_9" value="9" />
-		</control>
+		<!-- Known control kept disabled due to destructive behavior risk. -->
+		<!-- Control 0x08: +/0/0 C [Restore Factory Default Color] -->
+
+		<!-- Input source values were not explicitly confirmed in the issue. -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
+		<!--
+			Unverified candidate mappings inherited from the previous SAM7119 include:
+			<control id="inputsource" type="list" address="0x60">
+				<value id="dp" value="9"/>
+				<value id="hdmi" value="6"/>
+			</control>
+		-->
+
+		<!--
+			Unverified candidate mapping from the previous SAM7476 profile.
+			The issue scan reports 0xdb as unknown, so this remains disabled:
+			<control id="screensize" address="0xdb">
+				<value id="auto" value="0"/>
+				<value id="wide" value="1"/>
+				<value id="17_4_3" value="2"/>
+				<value id="19_4_3" value="3"/>
+				<value id="19_wide_16_10" value="4"/>
+				<value id="21_5_wide_16_9" value="5"/>
+				<value id="22_wide_16_10" value="6"/>
+				<value id="23_wide_16_9" value="7"/>
+				<value id="27_wide_16_9" value="8"/>
+				<value id="29_wide_21_9" value="9"/>
+			</control>
+		-->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x09: +/120/1   [???] -->
+		<!-- Control 0x0a: +/0/1   [???] -->
+		<!-- Control 0x0d: +/3/6   [???] -->
+		<!-- Control 0x0f: +/3/6   [???] -->
+		<!-- Control 0x14: +/4/5 C [???] -->
+		<!-- Control 0x23: +/2/3   [???] -->
+		<!-- Control 0x25: +/4/23   [???] -->
+		<!-- Control 0x28: +/0/0   [???] -->
+		<!-- Control 0x29: +/0/0   [???] -->
+		<!-- Control 0x2a: +/0/0   [???] -->
+		<!-- Control 0x2b: +/1/1   [???] -->
+		<!-- Control 0x2c: +/1/1   [???] -->
+		<!-- Control 0x2d: +/0/6   [???] -->
+		<!-- Control 0x2e: +/0/3   [???] -->
+		<!-- Control 0x2f: +/5/10   [???] -->
+		<!-- Control 0x87: +/10/20   [???] -->
+		<!-- Control 0x8d: +/0/255 C [???] -->
+		<!-- Control 0xaa: +/0/0   [???] -->
+		<!-- Control 0xb6: +/3/9   [???] -->
+		<!-- Control 0xc6: +/1/1   [???] -->
+		<!-- Control 0xc8: +/5/16   [???] -->
+		<!-- Control 0xc9: +/1/1   [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/30   [???] -->
+		<!-- Control 0xd6: +/0/0   [???] -->
+		<!-- Control 0xdb: +/0/9   [???] -->
+		<!-- Control 0xdc: +/2/3   [???] -->
+		<!-- Control 0xdf: +/512/514   [???] -->
+		<!-- Control 0xe0: +/4/5   [???] -->
+		<!-- Control 0xe5: +/0/1   [???] -->
+		<!-- Control 0xe6: +/0/0   [???] -->
+		<!-- Control 0xe7: +/0/0   [???] -->
+		<!-- Control 0xe9: +/0/1   [???] -->
+		<!-- Control 0xf7: +/1/3   [???] -->
+		<!-- Control 0xfe: +/2/2   [???] -->
 	</controls>
+	<!-- VESA include is safe: reset, unverified and unsupported controls are explicitly removed above. -->
+	<include file="VESA"/>
 </monitor>
-<!--
-Control 0x02: +/255/2 C [New Control Value]
-Control 0x08: +/0/0 C [Restore Factory Default Color]
-Control 0x09: +/120/1   [???]
-Control 0x0a: +/0/1   [???]
-Control 0x0d: +/3/6   [???]
-Control 0x0f: +/3/6   [???]
-Control 0x10: +/40/50 C [Brightness]
-Control 0x12: +/50/50 C [Contrast]
-Control 0x14: +/4/5 C [???]
-Control 0x16: +/50/100 C [Red maximum level]
-Control 0x18: +/50/100 C [Green maximum level]
-Control 0x1a: +/50/100 C [Blue maximum level]
-Control 0x23: +/1/3   [???]
-Control 0x25: +/4/23   [???]
-Control 0x28: +/0/0   [???]
-Control 0x29: +/0/0   [???]
-Control 0x2a: +/0/0   [???]
-Control 0x2b: +/1/1   [???]
-Control 0x2c: +/0/1   [???]
-Control 0x2d: +/0/6   [???]
-Control 0x2e: +/0/3   [???]
-Control 0x2f: +/5/10   [Black Equalizer (read only)]
-Control 0x60: +/15/3 C [Input Source Select (Main)]
-Control 0x62: +/0/100 C [???]
-Control 0x87: +/10/20   [???]
-Control 0x8d: +/0/255 C [???]
-Control 0xaa: +/0/0   [???]
-Control 0xb6: +/3/9   [???]
-Control 0xc6: +/1/1   [???]
-Control 0xc8: +/5/16   [???]
-Control 0xc9: +/1/1   [???]
-Control 0xca: +/2/2   [???]
-Control 0xcc: +/2/30   [???]
-Control 0xd6: +/0/0   [???]
-Control 0xdb: +/0/9   [Screen Size]
-Control 0xdc: +/8/3   [???]
-Control 0xdf: +/512/514   [???]
-Control 0xe0: +/4/5   [???]
-Control 0xe5: +/0/1   [???]
-Control 0xe6: +/0/0   [???]
-Control 0xe7: +/0/0   [???]
-Control 0xe9: +/0/1   [???]
-Control 0xf7: +/0/3   [???]
-Control 0xfe: +/2/2   [???]
--->

--- a/db/monitor/SAM7476.xml
+++ b/db/monitor/SAM7476.xml
@@ -1,79 +1,67 @@
 <?xml version="1.0"?>
 <!-- https://github.com/ddccontrol/ddccontrol-db/issues/261 -->
 <monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA" init="standard">
-	<!--
-		Conservative profile based on issue-provided scan output.
-		Infinity Core Lighting is not exposed by the monitor over DDC.
-	-->
-	<caps add="(type(lcd)vcp(02 10 12 16 18 1A 62))" remove="(vcp(00 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
-	<controls>
-		<!-- Known control kept disabled due to destructive behavior risk. -->
-		<!-- Control 0x08: +/0/0 C [Restore Factory Default Color] -->
-
-		<!-- Input source values were not explicitly confirmed in the issue. -->
-		<!-- Control 0x60: +/15/3 C [Input Source Select (Main)] -->
-		<!--
-			Unverified candidate mappings inherited from the previous SAM7119 include:
-			<control id="inputsource" type="list" address="0x60">
-				<value id="dp" value="9"/>
-				<value id="hdmi" value="6"/>
-			</control>
-		-->
-
-		<!--
-			Unverified candidate mapping from the previous SAM7476 profile.
-			The issue scan reports 0xdb as unknown, so this remains disabled:
-			<control id="screensize" address="0xdb">
-				<value id="auto" value="0"/>
-				<value id="wide" value="1"/>
-				<value id="17_4_3" value="2"/>
-				<value id="19_4_3" value="3"/>
-				<value id="19_wide_16_10" value="4"/>
-				<value id="21_5_wide_16_9" value="5"/>
-				<value id="22_wide_16_10" value="6"/>
-				<value id="23_wide_16_9" value="7"/>
-				<value id="27_wide_16_9" value="8"/>
-				<value id="29_wide_21_9" value="9"/>
-			</control>
-		-->
-
-		<!-- Unknown controls from the issue output (left commented for future investigation): -->
-		<!-- Control 0x09: +/120/1   [???] -->
-		<!-- Control 0x0a: +/0/1   [???] -->
-		<!-- Control 0x0d: +/3/6   [???] -->
-		<!-- Control 0x0f: +/3/6   [???] -->
-		<!-- Control 0x14: +/4/5 C [???] -->
-		<!-- Control 0x23: +/2/3   [???] -->
-		<!-- Control 0x25: +/4/23   [???] -->
-		<!-- Control 0x28: +/0/0   [???] -->
-		<!-- Control 0x29: +/0/0   [???] -->
-		<!-- Control 0x2a: +/0/0   [???] -->
-		<!-- Control 0x2b: +/1/1   [???] -->
-		<!-- Control 0x2c: +/1/1   [???] -->
-		<!-- Control 0x2d: +/0/6   [???] -->
-		<!-- Control 0x2e: +/0/3   [???] -->
-		<!-- Control 0x2f: +/5/10   [???] -->
-		<!-- Control 0x87: +/10/20   [???] -->
-		<!-- Control 0x8d: +/0/255 C [???] -->
-		<!-- Control 0xaa: +/0/0   [???] -->
-		<!-- Control 0xb6: +/3/9   [???] -->
-		<!-- Control 0xc6: +/1/1   [???] -->
-		<!-- Control 0xc8: +/5/16   [???] -->
-		<!-- Control 0xc9: +/1/1   [???] -->
-		<!-- Control 0xca: +/2/2   [???] -->
-		<!-- Control 0xcc: +/2/30   [???] -->
-		<!-- Control 0xd6: +/0/0   [???] -->
-		<!-- Control 0xdb: +/0/9   [???] -->
-		<!-- Control 0xdc: +/2/3   [???] -->
-		<!-- Control 0xdf: +/512/514   [???] -->
-		<!-- Control 0xe0: +/4/5   [???] -->
-		<!-- Control 0xe5: +/0/1   [???] -->
-		<!-- Control 0xe6: +/0/0   [???] -->
-		<!-- Control 0xe7: +/0/0   [???] -->
-		<!-- Control 0xe9: +/0/1   [???] -->
-		<!-- Control 0xf7: +/1/3   [???] -->
-		<!-- Control 0xfe: +/2/2   [???] -->
-	</controls>
-	<!-- VESA include is safe: reset, unverified and unsupported controls are explicitly removed above. -->
+	<caps add="(vcp(2F DB(0 1 2 3 4 5 6 7 8 9)))" />
+	<include file="SAM7119" />
 	<include file="VESA"/>
+	<controls>
+		<control id="screensize" address="0xdb">
+			<value id="auto" value="0" />
+			<value id="wide" value="1" />
+			<value id="17_4_3" value="2" />
+			<value id="19_4_3" value="3" />
+			<value id="19_wide_16_10" value="4" />
+			<value id="21_5_wide_16_9" value="5" />
+			<value id="22_wide_16_10" value="6" />
+			<value id="23_wide_16_9" value="7" />
+			<value id="27_wide_16_9" value="8" />
+			<value id="29_wide_21_9" value="9" />
+		</control>
+	</controls>
 </monitor>
+<!--
+Control 0x02: +/255/2 C [New Control Value]
+Control 0x08: +/0/0 C [Restore Factory Default Color]
+Control 0x09: +/120/1   [???]
+Control 0x0a: +/0/1   [???]
+Control 0x0d: +/3/6   [???]
+Control 0x0f: +/3/6   [???]
+Control 0x10: +/40/50 C [Brightness]
+Control 0x12: +/50/50 C [Contrast]
+Control 0x14: +/4/5 C [???]
+Control 0x16: +/50/100 C [Red maximum level]
+Control 0x18: +/50/100 C [Green maximum level]
+Control 0x1a: +/50/100 C [Blue maximum level]
+Control 0x23: +/1/3   [???]
+Control 0x25: +/4/23   [???]
+Control 0x28: +/0/0   [???]
+Control 0x29: +/0/0   [???]
+Control 0x2a: +/0/0   [???]
+Control 0x2b: +/1/1   [???]
+Control 0x2c: +/0/1   [???]
+Control 0x2d: +/0/6   [???]
+Control 0x2e: +/0/3   [???]
+Control 0x2f: +/5/10   [Black Equalizer (read only)]
+Control 0x60: +/15/3 C [Input Source Select (Main)]
+Control 0x62: +/0/100 C [???]
+Control 0x87: +/10/20   [???]
+Control 0x8d: +/0/255 C [???]
+Control 0xaa: +/0/0   [???]
+Control 0xb6: +/3/9   [???]
+Control 0xc6: +/1/1   [???]
+Control 0xc8: +/5/16   [???]
+Control 0xc9: +/1/1   [???]
+Control 0xca: +/2/2   [???]
+Control 0xcc: +/2/30   [???]
+Control 0xd6: +/0/0   [???]
+Control 0xdb: +/0/9   [Screen Size]
+Control 0xdc: +/8/3   [???]
+Control 0xdf: +/512/514   [???]
+Control 0xe0: +/4/5   [???]
+Control 0xe5: +/0/1   [???]
+Control 0xe6: +/0/0   [???]
+Control 0xe7: +/0/0   [???]
+Control 0xe9: +/0/1   [???]
+Control 0xf7: +/0/3   [???]
+Control 0xfe: +/2/2   [???]
+-->


### PR DESCRIPTION
## Summary

- preserve the existing `SAM7476` Samsung Odyssey Neo G9 profile and all current controls, including the `screensize` mapping
- add a header linking the profile to issue #261
- include the standard `VESA` profile directly without removing or remapping existing controls

This is intentionally an additive-only change. Existing input-source and screen-size mappings are unchanged, and controls reported as `???` remain documented in comments for future investigation.

Infinity Core Lighting is not added because the issue discussion confirms that the monitor does not expose it over DDC.

Hardware verification from the issue author is requested before enabling any additional controls or changing monitor-specific mappings.

## Validation

- `xmllint --noout db/monitor/SAM7476.xml`
- `make check-db`
- `ddccontrol -b db -v -v -i SAM7476`
- `git diff origin/master --check`

Fixes #261
