### PR TITLE
docs: document LG 27GL850 scan controls

### DIFF
--- a/db/monitor/GSM5B7F.xml
+++ b/db/monitor/GSM5B7F.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/218 -->
 <!-- https://www.lg.com/us/monitors/lg-27GL850-B-gaming-monitor -->
 <!-- Note: This model is referred to as both LG-27GL850 and LG-27GL850-B -->
 <monitor name="LG UltraGear 27GL850" init="standard">
@@ -160,6 +161,75 @@
 			<value id="on" value="1"/>
 			<value id="off" value="0"/>
 		</control>
+
+		<!--
+			Named controls from the issue scan are already exposed above or
+			through the VESA include: 02 04 05 08 10 12 16 18 1A 60 62 D6.
+
+			The issue scan reported the controls below as unknown. Preserve
+			the readings verbatim for future hardware investigation; they do
+			not establish or alter any semantic mappings.
+		-->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/35/100   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/65500/11 C [???] -->
+		<!-- Control 0x15: +/15/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x4d: +/32770/65535 C [???] -->
+		<!-- Control 0x4e: +/8192/65535 C [???] -->
+		<!-- Control 0x4f: +/7042/65535 C [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x59: +/50/100   [???] -->
+		<!-- Control 0x5a: +/50/100   [???] -->
+		<!-- Control 0x5b: +/50/100   [???] -->
+		<!-- Control 0x5c: +/50/100   [???] -->
+		<!-- Control 0x5d: +/50/100   [???] -->
+		<!-- Control 0x5e: +/50/100   [???] -->
+		<!-- Control 0x69: +/6500/10000   [???] -->
+		<!-- Control 0x6a: +/143/255   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x72: +/30720/100   [???] -->
+		<!-- Control 0x7a: +/240/100   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8d: +/2/100 C [???] -->
+		<!-- Control 0x9b: +/50/100   [???] -->
+		<!-- Control 0x9c: +/50/100   [???] -->
+		<!-- Control 0x9d: +/50/100   [???] -->
+		<!-- Control 0x9e: +/50/100   [???] -->
+		<!-- Control 0x9f: +/50/100   [???] -->
+		<!-- Control 0xa0: +/50/100   [???] -->
+		<!-- Control 0xac: +/17692/3 C [???] -->
+		<!-- Control 0xae: +/14325/0 C [???] -->
+		<!-- Control 0xaf: +/50/255   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/5418/65535 C [???] -->
+		<!-- Control 0xc6: +/104/65535 C [???] -->
+		<!-- Control 0xc8: +/5/255 C [???] -->
+		<!-- Control 0xc9: +/792/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/0/255   [???] -->
+		<!-- Control 0xd7: +/255/65535   [???] -->
+		<!-- Control 0xd8: +/1/65535   [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe2: +/1/255   [???] -->
+		<!-- Control 0xeb: +/0/1   [???] -->
+		<!-- Control 0xef: +/21568/65535 C [???] -->
+		<!-- Control 0xf4: +/6/65535 C [???] -->
+		<!-- Control 0xf5: +/1/255 C [???] -->
+		<!-- Control 0xf6: +/0/255 C [???] -->
+		<!-- Control 0xf7: +/2/255 C [???] -->
+		<!-- Control 0xf8: +/1/255 C [???] -->
+		<!-- Control 0xf9: +/50/255 C [???] -->
+		<!-- Control 0xfa: +/255/255   [???] -->
+		<!-- Control 0xfb: +/2/65535   [???] -->
+		<!-- Control 0xfe: +/3/255 C [???] -->
 	</controls>
 
 	<include file="VESA"/>


### PR DESCRIPTION
## Summary

- link the `GSM5B7F` monitor profile to issue #218
- preserve all 60 controls reported as `???` in the scan, verbatim and commented out
- document that the explicitly named scan controls are already provided by the profile or its `VESA` include

## Safety

This is an intentionally conservative, additive-only update: it adds 70 lines and removes none. No existing mapping is changed, and no new active control is exposed because every explicitly named safe control from the scan is already available.

Unknown and candidate mappings remain commented out. Hardware verification from the issue author is requested before enabling any additional controls.

## Validation

- `xmllint --noout db/monitor/GSM5B7F.xml`
- `make check`
- `make check-db`
- `git diff --check`
- verified diff: 70 additions, 0 deletions

Fixes #218
