### PR TITLE
docs: record Dell U2515H scan

### DIFF
--- a/db/monitor/DELD06F.xml
+++ b/db/monitor/DELD06F.xml
@@ -1,4 +1,46 @@
 <?xml version="1.0"?>
+<!--
+https://github.com/ddccontrol/ddccontrol-db/issues/42
+
+The explicitly named controls from this scan are provided by DELD070 and its
+VESA include. The issue confirms mDP (0x10) and HDMI 1 (0x11); other existing
+input mappings come from the shared U2515H profile and remain unverified for
+this particular revision.
+-->
 <monitor name="Dell U2515H" init="standard">
+	<!-- Unknown controls reported by the scan; disabled pending hardware verification.
+	Control 0x06: +/0/1   [???]
+	Control 0x0b: +/100/0   [???]
+	Control 0x0e: +/100/0   [???]
+	Control 0x14: +/5/12 C [???]
+	Control 0x1e: +/0/1   [???]
+	Control 0x1f: +/0/1   [???]
+	Control 0x20: +/0/1   [???]
+	Control 0x30: +/0/1   [???]
+	Control 0x3e: +/0/1   [???]
+	Control 0x52: +/242/255 C [???]
+	Control 0x6c: +/16/18   [???]
+	Control 0x6e: +/16/18   [???]
+	Control 0x70: +/16/18   [???]
+	Control 0xac: +/23564/1 C [???]
+	Control 0xae: +/6010/65535 C [???]
+	Control 0xb2: +/1/1 C [???]
+	Control 0xb6: +/3/5 C [???]
+	Control 0xc0: +/3225/65535   [???]
+	Control 0xc6: +/17868/65535 C [???]
+	Control 0xc8: +/4361/17 C [???]
+	Control 0xc9: +/256/65535 C [???]
+	Control 0xca: +/1/2   [???]
+	Control 0xcc: +/2/11   [???]
+	Control 0xdc: +/0/5 C [???]
+	Control 0xdf: +/513/65535 C [???]
+	Control 0xe0: +/0/1 C [???]
+	Control 0xe2: +/0/25 C [???]
+	Control 0xf0: +/0/255 C [???]
+	Control 0xf1: +/3/255 C [???]
+	Control 0xf2: +/0/255 C [???]
+	Control 0xfc: +/0/255   [???]
+	Control 0xfd: +/99/255 C [???]
+	-->
 	<include file="DELD070"/>
 </monitor>


### PR DESCRIPTION
## Summary

- link the existing `DELD06F` profile to issue #42
- document that the confirmed mDP and HDMI 1 values are already provided by the shared U2515H profile
- preserve every control reported as `???` as a disabled comment

## Safety

The profile remains intentionally conservative. No active controls or enum mappings are changed. Existing shared mappings that were not confirmed by this scan remain unverified candidates.

Hardware verification is requested from the issue author before enabling any additional controls or treating other input mappings as confirmed for this monitor revision.

## Validation

- `xmllint --noout db/monitor/DELD06F.xml`
- `ddccontrol -b db -v -v -i DELD06F`
- `make check`
- `git diff --check`

Fixes #42
