### PR TITLE
feat: expand VESA fallback mappings

### DIFF
--- a/db/monitor/VESA.xml
+++ b/db/monitor/VESA.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <!--- "Standard" controls -->
+<!-- Expanded standard mappings: https://github.com/ddccontrol/ddccontrol-db/issues/174 -->
 <monitor name="VESA standard monitor" init="standard">
 	<controls>
 		<control id="degauss" address="0x00"/>
@@ -51,8 +52,26 @@
 		<control id="vmoire" address="0x58"/>
 		
 		<control id="inputsource" type="list" address="0x60">
-			<value id="analog"  value="1"/>
-			<value id="digital" value="3"/>
+			<!-- MCCS 2.2 standard input source values. Monitor-specific profiles
+			     should override this list when the display uses vendor mappings. -->
+			<value id="vga1" value="0x01"/>
+			<value id="vga2" value="0x02"/>
+			<value id="dvi1" value="0x03"/>
+			<value id="dvi2" value="0x04"/>
+			<value id="composite1" value="0x05"/>
+			<value id="composite2" value="0x06"/>
+			<value id="s-video1" value="0x07"/>
+			<value id="s-video2" value="0x08"/>
+			<value id="tuner1" value="0x09"/>
+			<value id="tuner2" value="0x0a"/>
+			<value id="tuner3" value="0x0b"/>
+			<value id="component1" value="0x0c"/>
+			<value id="component2" value="0x0d"/>
+			<value id="component3" value="0x0e"/>
+			<value id="dp1" value="0x0f"/>
+			<value id="dp2" value="0x10"/>
+			<value id="hdmi1" value="0x11"/>
+			<value id="hdmi2" value="0x12"/>
 		</control>
 		<control id="audiospeakervolume" address="0x62"/>
 		
@@ -64,12 +83,59 @@
 			<value id="landscape" value="1"/>
 			<value id="portrait" value="2"/>
 		</control>
+
+		<control id="language" type="list" address="0xcc">
+			<!-- MCCS 2.2 standard OSD language values. Reserved value 0x00 is
+			     intentionally omitted. -->
+			<value id="chinese_tw" value="0x01"/>
+			<value id="english" value="0x02"/>
+			<value id="french" value="0x03"/>
+			<value id="german" value="0x04"/>
+			<value id="italian" value="0x05"/>
+			<value id="japanese" value="0x06"/>
+			<value id="korean" value="0x07"/>
+			<value id="portuguese" value="0x08"/>
+			<value id="russian" value="0x09"/>
+			<value id="spanish" value="0x0a"/>
+			<value id="swedish" value="0x0b"/>
+			<value id="turkish" value="0x0c"/>
+			<value id="chinese" value="0x0d"/>
+			<value id="brazilian" value="0x0e"/>
+			<value id="arabic" value="0x0f"/>
+			<value id="bulgarian" value="0x10"/>
+			<value id="croatian" value="0x11"/>
+			<value id="czech" value="0x12"/>
+			<value id="danish" value="0x13"/>
+			<value id="dutch" value="0x14"/>
+			<value id="estonian" value="0x15"/>
+			<value id="finnish" value="0x16"/>
+			<value id="greek" value="0x17"/>
+			<value id="hebrew" value="0x18"/>
+			<value id="hindi" value="0x19"/>
+			<value id="hungarian" value="0x1a"/>
+			<value id="latvian" value="0x1b"/>
+			<value id="lithuanian" value="0x1c"/>
+			<value id="norwegian" value="0x1d"/>
+			<value id="polish" value="0x1e"/>
+			<value id="romanian" value="0x1f"/>
+			<value id="serbian" value="0x20"/>
+			<value id="slovak" value="0x21"/>
+			<value id="slovenian" value="0x22"/>
+			<value id="thai" value="0x23"/>
+			<value id="ukrainian" value="0x24"/>
+			<value id="vietnamese" value="0x25"/>
+		</control>
 		
 		<control id="settings" address="0xb0" delay="1000"/>
 		
-		<control id="dpms" address="0xd6">
-			<value id="on" value="1"/>
-			<value id="standby" value="4"/>
+		<control id="dpms" type="list" address="0xd6">
+			<value id="on" value="0x01"/>
+			<value id="standby" value="0x02"/>
+			<value id="suspend" value="0x03"/>
+			<value id="off" value="0x04"/>
+			<!-- MCCS value 0x05 is a write-only command that turns off the
+			     display. Keep it unavailable in the generic fallback. -->
+			<!-- <value id="poweroff" value="0x05"/> -->
 		</control>
 		
 		<control id="power" type="list" address="0xe1">

--- a/db/monitor/VESA.xml
+++ b/db/monitor/VESA.xml
@@ -133,9 +133,9 @@
 			<value id="standby" value="0x02"/>
 			<value id="suspend" value="0x03"/>
 			<value id="off" value="0x04"/>
-			<!-- MCCS value 0x05 is a write-only command that turns off the
-			     display. Keep it unavailable in the generic fallback. -->
-			<!-- <value id="poweroff" value="0x05"/> -->
+			<!-- MCCS value 0x05 is a write-only command, so reading the
+			     control will not report this value as the current state. -->
+			<value id="poweroff" value="0x05"/>
 		</control>
 		
 		<control id="power" type="list" address="0xe1">

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -664,13 +664,24 @@
 				<value id="hdmi1" name="HDMI-1"/>
 				<value id="hdmi2" name="HDMI-2"/>
 				<value id="hdmi3" name="HDMI-3"/>
-					<value id="hdmi-mhl" name="HDMI (MHL)"/>
-					<value id="mdp" name="mDP"/>
-					<value id="vga" name="VGA"/>
-					<value id="vga1" name="VGA-1"/>
-					<value id="component" name="Component"/>
+				<value id="hdmi-mhl" name="HDMI (MHL)"/>
+				<value id="mdp" name="mDP"/>
+				<value id="vga" name="VGA"/>
+				<value id="vga1" name="VGA-1"/>
+				<value id="vga2" name="VGA-2"/>
+				<value id="component" name="Component"/>
+				<value id="component1" name="Component video 1"/>
+				<value id="component2" name="Component video 2"/>
+				<value id="component3" name="Component video 3"/>
 				<value id="s-video" name="S-Video"/>
+				<value id="s-video1" name="S-Video-1"/>
+				<value id="s-video2" name="S-Video-2"/>
 				<value id="composite" name="Composite"/>
+				<value id="composite1" name="Composite video 1"/>
+				<value id="composite2" name="Composite video 2"/>
+				<value id="tuner1" name="Tuner-1"/>
+				<value id="tuner2" name="Tuner-2"/>
+				<value id="tuner3" name="Tuner-3"/>
 				<value id="usb-c" name="USB-C"/>
 			</control>
 			<control id="autosource" type="list" name="Autoselect Input Source" address="0xe2">
@@ -763,15 +774,14 @@
 				<value id="chinese"       name="简体中文 (Simplified Chinese)"/>
 				<value id="dutch"         name="Nederlands (Dutch)"/>
 				<value id="japanese"      name="日本語 (Japanese)"/>
-					<value id="polish"        name="Polski (Polish)"/>
-					<value id="greek"         name="Ελληνικά (Greek)"/>
-					<value id="czech"         name="Český (Czech)"/>
+				<value id="polish"        name="Polski (Polish)"/>
+				<value id="greek"         name="Ελληνικά (Greek)"/>
+				<value id="czech"         name="Český (Czech)"/>
 				<value id="hungarian"     name="Magyar (Hungarian)"/>
 				<value id="romanian"      name="Română (Romanian)"/>
 				<value id="portuguese"    name="Português (Portuguese)"/>
 				<value id="serbocroatian" name="SiGC/BiH/CRO (Serbo-Croatian)"/>
 				<value id="hindi"         name="हिन्दी (India)"/>
-				<value id="finnish"       name="Suomalainen (Finnish)"/>
 				<value id="turkish"       name="Türk (Turkish)"/>
 				<value id="brazilian"     name="Português do Brasil (Brazilian Portuguese)"/>
 				<value id="malay"         name="Bahasa Melayu (Malay)"/>
@@ -780,6 +790,18 @@
 				<value id="ukrainian"     name="українська (Ukrainian)"/>
 				<value id="persian"       name="فارسی (Persian)"/>
 				<value id="indonesian"    name="Bahasa Indonesia (Indonesian)"/>
+				<value id="bulgarian"     name="Български (Bulgarian)"/>
+				<value id="croatian"      name="Hrvatski (Croatian)"/>
+				<value id="danish"        name="Dansk (Danish)"/>
+				<value id="estonian"      name="Eesti (Estonian)"/>
+				<value id="hebrew"        name="עברית (Hebrew)"/>
+				<value id="latvian"       name="Latviešu (Latvian)"/>
+				<value id="lithuanian"    name="Lietuvių (Lithuanian)"/>
+				<value id="norwegian"     name="Norsk (Norwegian)"/>
+				<value id="serbian"       name="Српски (Serbian)"/>
+				<value id="slovak"        name="Slovenčina (Slovak)"/>
+				<value id="slovenian"     name="Slovenščina (Slovenian)"/>
+				<value id="vietnamese"    name="Tiếng Việt (Vietnamese)"/>
 			</control>
 			<!-- If "changed", read 0x52 register value to get address of the control changed using OSD menu -->
 			<control id="newcontrolvalue" type="list" name="New Control Value" address="0x02">


### PR DESCRIPTION
## Summary

- replace the two generic input-source entries with all 18 MCCS 2.2 standard values for VCP `0x60`
- add all 37 non-reserved MCCS 2.2 OSD language values for VCP `0xcc`
- correct VCP `0xd6` value `0x04` from Standby to Off, add Standby and Suspend, and expose the standardized write-only `0x05` Power off command
- add the option IDs and labels needed by the expanded fallback mappings

## Safety and verification

This profile is intentionally conservative: only MCCS-defined mappings are active, with no unverified vendor-specific inference. Unverified candidate mappings remain excluded/commented out.

The `0xd6=0x05` entry is explicitly documented as write-only. It can be sent deliberately, but must not be expected when reading the current power state. Monitor-specific profiles continue to override these fallback controls.

Hardware verification is requested from the issue author and other affected users. Monitor capability strings and implementations are not always reliable, and ddccontrol currently filters generic controls by VCP address but not their individual enum values. Follow-up tracking for capability-based value filtering: [ddccontrol/ddccontrol#308](https://github.com/ddccontrol/ddccontrol/issues/308).

## Validation

- `xmllint --noout db/options.xml db/monitor/VESA.xml`
- `make check`
- `make check-db` (902 successful database checks)
- `DDCCONTROL_DB_TEST_DATADIR="$PWD" cargo test -p ddccontrol-db --manifest-path ../ddccontrol/Cargo.toml` (16 passed)

Fixes #174
