### PR TITLE
feat: add Lenovo P44w-10 monitor profile

### DIFF
--- a/db/monitor/LEN61D5.xml
+++ b/db/monitor/LEN61D5.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/121 -->
+<monitor name="Lenovo ThinkVision P44w-10" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 62 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/50/100 C [Brightness] -->
+		<!-- Control 0x12: +/60/100 C [Contrast] -->
+		<!-- Control 0x16: +/100/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/100/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/100/100 C [Blue maximum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, and power controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [Secondary Degauss - Secondary Degauss] -->
+		<!-- Control 0x04: +/0/255 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/255 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/14 C [Input Source Select (Main)] -->
+		<!-- Control 0xd6: +/1/255 C [DPMS Control - On] -->
+
+		<!--
+			Unverified input-source candidates advertised by the capabilities
+			string. Their meanings are unknown, so no mappings are enabled.
+
+			<control id="inputsource" type="list" address="0x60">
+				<value id="unverified-0x0f" value="0x0f"/>
+				<value id="unverified-0x11" value="0x11"/>
+				<value id="unverified-0x12" value="0x12"/>
+				<value id="unverified-0x13" value="0x13"/>
+				<value id="unverified-0x14" value="0x14"/>
+			</control>
+		-->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/6/255 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x62: +/100/100   [???] -->
+		<!-- Control 0x68: +/0/5   [???] -->
+		<!-- Control 0x6c: +/50/255   [???] -->
+		<!-- Control 0x6e: +/50/255   [???] -->
+		<!-- Control 0x70: +/50/255   [???] -->
+		<!-- Control 0x86: +/2/255 C [???] -->
+		<!-- Control 0x95: +/0/1920 C [???] -->
+		<!-- Control 0x96: +/0/600 C [???] -->
+		<!-- Control 0xa4: +/43690/65535 C [???] -->
+		<!-- Control 0xa5: +/0/65535 C [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/17028/2 C [???] -->
+		<!-- Control 0xae: +/12139/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/62/65535   [???] -->
+		<!-- Control 0xc6: +/67/255 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/259/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xcc: +/2/0 C [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/514/255 C [???] -->
+		<!-- Control 0xe0: +/1/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xea: +/0/255 C [???] -->
+		<!-- Control 0xec: +/0/255 C [???] -->
+		<!-- Control 0xed: +/1/255 C [???] -->
+		<!-- Control 0xef: +/1/255 C [???] -->
+		<!-- Control 0xf0: +/3/255 C [???] -->
+		<!-- Control 0xf1: +/1/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xf4: +/0/100 C [???] -->
+		<!-- Control 0xf5: +/65280/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfd: +/0/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a monitor profile for the Lenovo ThinkVision P44w-10 with PNP ID `LEN61D5`
- expose only the explicitly named, non-destructive brightness, contrast, and RGB controls
- preserve every unknown control from the issue scan as a comment for future investigation

## Safety

The profile is intentionally conservative. Reset, input-source, and DPMS controls are disabled until their write behavior is verified on hardware. The input-source values advertised by the capabilities string are included only as commented, unverified candidates; no semantic mappings were inferred.

Hardware verification is requested from the issue author before enabling any additional controls, especially the input-source, KVM, PBP, and PIP-related controls.

## Validation

- `xmllint --noout db/monitor/LEN61D5.xml`
- `./configure --prefix=/usr --disable-nls`
- `make check`
- `make check-db DDCCONTROL=ddccontrol`
- direct `ddccontrol -b db -v -v -i LEN61D5` integrity check

Fixes #121
