### PR TITLE
ci: rebuild website after database releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,8 @@ jobs:
   publish-release:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-')) }}
     runs-on: ubuntu-24.04
+    outputs:
+      release_date: ${{ steps.version.outputs.release_date }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -129,3 +131,25 @@ jobs:
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.gz \
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.bz2 \
             "$RUNNER_TEMP"/release-artifacts/ddccontrol-db-*.tar.xz
+
+  notify-website:
+    needs: publish-release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      WEBSITE_DISPATCH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+    steps:
+      - name: Trigger website rebuild
+        if: ${{ env.WEBSITE_DISPATCH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ env.WEBSITE_DISPATCH_TOKEN }}
+          RELEASE_DATE: ${{ needs.publish-release.outputs.release_date }}
+        run: |
+          gh api --method POST repos/ddccontrol/ddccontrol.github.io/dispatches \
+            --field event_type=ddccontrol-db-release \
+            --field "client_payload[tag]=$RELEASE_DATE"
+
+      - name: Report missing website token
+        if: ${{ env.WEBSITE_DISPATCH_TOKEN == '' }}
+        run: echo "WEBSITE_DISPATCH_TOKEN is not configured; the scheduled website build will pick up this release."


### PR DESCRIPTION
## Summary

- expose the published database version as a job output
- add a post-release job that dispatches `ddccontrol-db-release` to `ddccontrol/ddccontrol.github.io`
- include the release date in the dispatch payload
- skip the dispatch cleanly when `WEBSITE_DISPATCH_TOKEN` is not configured

## Why

Publishing a monitor database release currently does not notify the project website. Without this signal, release notes, download assets, and the generated monitor index wait for the scheduled fallback build.

## Impact

Once `WEBSITE_DISPATCH_TOKEN` is configured, a successful database release triggers an immediate website rebuild. Release publishing still succeeds when the token is absent.

## Validation

- branched from the current `origin/master`
- confirmed the GitHub diff contains only `.github/workflows/publish-release.yml`
- ran `actionlint` and `git diff --check`

## Configuration

Add a repository secret named `WEBSITE_DISPATCH_TOKEN` with permission to dispatch workflows in `ddccontrol/ddccontrol.github.io`.
