### PR TITLE
fix: document Dell U2414H scan controls

### DIFF
--- a/db/monitor/DELA0A4.xml
+++ b/db/monitor/DELA0A4.xml
@@ -4,8 +4,8 @@ Reports:
 https://github.com/ddccontrol/ddccontrol-db/issues/10
 https://github.com/ddccontrol/ddccontrol-db/issues/59
 
-The scans in issue #10 have identical capabilities and controls. Their
-different current values reflect monitor settings, not separate profiles.
+The scans in issues #10 and #59 have identical capabilities and controls.
+Their different current values reflect monitor settings, not separate profiles.
 
 No DDC over DP and mDP. No control from HDMI1 when HDMI2 is displayed and vice versa.
 Identifies as DELA0B2 on HDMI-2 input.
@@ -59,6 +59,52 @@ Identifies as DELA0B2 on HDMI-2 input.
 			<value id="portraitleft" value="2"/>
 			<value id="portraitright" value="4"/>
 		</control>
+
+		<!--
+			Unknown controls reported by issue #59, kept disabled for future
+			hardware investigation. Values use the scan's +/current/max format.
+
+			The active mappings for 0x14, 0xdc, and 0xf0 above predate issue #59
+			and are preserved; the issue itself did not identify their semantics.
+		-->
+		<!-- Control 0x02: +/1/2 C [???] -->
+		<!-- Control 0x06: +/0/255   [???] -->
+		<!-- Control 0x0b: +/0/24028   [???] -->
+		<!-- Control 0x0c: +/2/255   [???] -->
+		<!-- Control 0x0e: +/50/100   [???] -->
+		<!-- Control 0x14: +/1/12 C [???] -->
+		<!-- Control 0x1e: +/0/2   [???] -->
+		<!-- Control 0x20: +/242/100   [???] -->
+		<!-- Control 0x30: +/38/100   [???] -->
+		<!-- Control 0x3e: +/50/100   [???] -->
+		<!-- Control 0x52: +/0/255 C [???] -->
+		<!-- Control 0x6c: +/128/255   [???] -->
+		<!-- Control 0x6e: +/128/255   [???] -->
+		<!-- Control 0x70: +/128/255   [???] -->
+		<!-- Control 0xa8: +/0/3   [???] -->
+		<!-- Control 0xac: +/1964/1 C [???] -->
+		<!-- Control 0xae: +/6000/0 C [???] -->
+		<!-- Control 0xb2: +/1/8 C [???] -->
+		<!-- Control 0xb4: +/1/2   [???] -->
+		<!-- Control 0xb6: +/3/5 C [???] -->
+		<!-- Control 0xc0: +/242/65535   [???] -->
+		<!-- Control 0xc6: +/17868/65535 C [???] -->
+		<!-- Control 0xc8: +/22021/0 C [???] -->
+		<!-- Control 0xc9: +/257/65535 C [???] -->
+		<!-- Control 0xca: +/2/2   [???] -->
+		<!-- Control 0xdc: +/0/255 C [???] -->
+		<!-- Control 0xdf: +/513/255 C [???] -->
+		<!-- Control 0xe0: +/0/1 C [???] -->
+		<!-- Control 0xe2: +/11/255 C [???] -->
+		<!-- Control 0xe3: +/0/1   [???] -->
+		<!-- Control 0xf0: +/0/255 C [???] -->
+		<!-- Control 0xf1: +/3/255 C [???] -->
+		<!-- Control 0xf2: +/0/255 C [???] -->
+		<!-- Control 0xfa: +/0/65535   [???] -->
+		<!-- Control 0xfb: +/1/1   [???] -->
+		<!-- Control 0xfc: +/128/255   [???] -->
+		<!-- Control 0xfd: +/98/65535 C [???] -->
+		<!-- Control 0xff: +/0/65535   [???] -->
 
 	</controls>
 	<include file="VESA"/>


### PR DESCRIPTION
## Summary

- document the Dell U2414H `DELA0A4` scan from issue #59 in the existing monitor profile
- retain all 38 controls reported as `???` verbatim as disabled XML comments for future investigation
- preserve the profile's existing active controls and mappings, which predate issue #59

## Safety

This profile update is intentionally conservative. Candidate mappings and unknown controls from issue #59 remain commented out, and no new monitor-specific semantics or reset behavior is enabled. The existing profile continues to include `VESA` and retains its previously active functionality.

Hardware verification is requested from the issue author before enabling any additional controls or monitor-specific mappings.

## Validation

- `xmllint --noout db/monitor/DELA0A4.xml`
- verified all 38 `???` scan entries are present unchanged as comments
- `make`
- `make check`
- `make check-db`

Fixes #59
