### PR TITLE
docs: record LG 27UD58 candidate mappings

### DIFF
--- a/db/monitor/GSM5B09.xml
+++ b/db/monitor/GSM5B09.xml
@@ -7,12 +7,81 @@ https://github.com/ddccontrol/ddccontrol-db/issues/325
 
 LG reuses PNP ID GSM5B09 for several models. The monitor-specific mappings
 below were added for the 27UD68P and are unverified candidate mappings for
-the 27UD88, 27UD58, and 24UD58. In particular, input switching is reported
-as unreliable on the 27UD58 in issue #80.
+the 27UD88, 27UD58, and 24UD58. Input switching was not tested on the
+27UD58 in issue #80; later input-switching reports concern other LG models.
 -->
 <monitor name="LG 27UD68P / 27UD88 / 27UD58 / 24UD58" init="standard">
 	<caps add="(vcp(04 08 10 12 14(05 08 0B ) 16 18 1A 60( 11 12 0F 10) D6(01 04) 62 8D F5(00 01 02) F6(00 01 02) 15(01 07 08 11 13 14 15 18 19 20 22 23 24 28 29) F7(00 01 02 03) F8(00 01)))" remove="(vcp(02 05 4D 4E 4F 52 AC AE B2 B6 C0 C6 C8 C9 DF F4 F9 FE(00 01 02) FD(00 01) FF))"/>
 	<controls>
+		<!--
+		The following LG 27UD58 mappings were reverse-engineered over
+		DisplayPort in issue #80. The ddccontrol scan labels these controls
+		as unknown (???), the PNP ID is shared by several models, and some
+		reported values conflict with the monitor's capability string.
+		They are recorded only as unverified candidates. Hardware
+		verification is required before enabling any of them.
+
+		Picture presets may not reproduce every setting changed by the OSD,
+		and game modes may alter the availability of other controls.
+
+		<control id="lgmode" type="list" name="Picture Mode" address="0x15">
+			<value id="reader" name="Reader" value="1"/>
+			<value id="colorweaknes" name="Color Weakness" value="6"/>
+			<value id="darkroom1" name="Dark Room 1" value="9"/>
+			<value id="darkroom2" name="Dark Room 2" value="10"/>
+			<value id="custom" name="Custom" value="11"/>
+			<value id="rtsgame" name="RTS Game" value="13"/>
+			<value id="customgame" name="Custom (Game)" value="14"/>
+			<value id="fpsgame1" name="FPS Game 1" value="28"/>
+			<value id="fpsgame2" name="FPS Game 2" value="29"/>
+			<value id="photo" name="Photo" value="32"/>
+			<value id="cinema" name="Cinema" value="48"/>
+		</control>
+
+		<control id="sharpness" type="value" name="Sharpness" address="0x87" min="0" max="100"/>
+
+		<control id="ratio" type="list" name="Screen ratio" address="0xF5">
+			<value id="wide" name="Wide" value="1"/>
+			<value id="original" name="Original" value="2"/>
+		</control>
+
+		<control id="energysaving" type="list" name="Smart Energy Saving" address="0xF6">
+			<value id="off" name="Off" value="0"/>
+			<value id="low" name="Low" value="1"/>
+			<value id="high" name="High" value="2"/>
+		</control>
+
+		<control id="responsetime" type="list" name="Response Time" address="0xF7">
+			<value id="off" name="Off" value="0"/>
+			<value id="high" name="High" value="1"/>
+			<value id="middle" name="Middle" value="2"/>
+			<value id="low" name="Low" value="3"/>
+		</control>
+
+		The capability string advertises FreeSync values 0 and 1, while the
+		issue reports 0, 2, and 3:
+		<control id="freesync" type="list" name="FreeSync" address="0xF8">
+			<value id="off" name="Off" value="0"/>
+			<value id="base" name="Basic" value="2"/>
+			<value id="extended" name="Extended" value="3"/>
+		</control>
+
+		The Black Stabilizer scale/encoding requires additional verification:
+		<control id="blackstabilization" type="value" name="Black Stabilizer" address="0xF9" min="0" max="100"/>
+
+		<control id="gammamode" type="list" name="Gamma" address="0xFE">
+			<value id="gamma0" name="Gamma 0" value="1"/>
+			<value id="gamma1" name="Gamma 1" value="2"/>
+			<value id="gamma2" name="Gamma 2" value="3"/>
+			<value id="off" name="Off" value="4"/>
+		</control>
+
+		Input source 0x60 was explicitly not tested on the 27UD58. Control
+		0x92 produced unusual language values and was described as potentially
+		unsafe. Controls 0xAC and 0xAE are read-only horizontal and vertical
+		frequency information, not DisplayPort 1.2 switches. No candidate
+		write mappings are provided for these controls.
+		-->
 		<control id="inputsource" type="list" address="0x60">
 			<value id="hdmi1"  value="0x11"/>
 			<value id="hdmi2" value="0x12"/>


### PR DESCRIPTION
## Summary

- Record the LG 27UD58 values reverse-engineered in issue #80 as commented, unverified candidate mappings.
- Document the capability-string conflicts and the controls that still require cautious hardware testing.
- Clarify that input switching was not tested on the 27UD58; the later input-switching reports concern other LG models.
- Preserve every existing active control and mapping in the shared `GSM5B09` profile.

## Rationale

LG reuses PNP ID `GSM5B09` across the 27UD68P, 27UD88, 27UD58, and 24UD58. The issue provides useful research data, but most manufacturer-specific controls are reported as `???` by the scan, and some values conflict with the monitor's capability string. Applying them to the shared profile without current hardware testing could affect other models or firmware revisions.

The profile remains intentionally conservative. All newly recorded candidate mappings are commented out, so this change does not alter runtime behavior. Input source, the unusual language values, and read-only frequency controls receive no candidate write mappings.

Hardware verification is requested from the issue author or another owner of a `GSM5B09` monitor before enabling any additional controls. Future test results should be filed in a new, focused issue referencing #80.

## Verification

- `xmllint --noout db/monitor/GSM5B09.xml`
- `./configure --prefix=/usr`
- `make check`
- `make check-db`
- `ddccontrol -b db -v -v -i GSM5B09`
- `git diff --check`

Fixes #80
