### PR TITLE
feat: add SPT08C4 monitor support

### DIFF
--- a/db/monitor/SPT08C4.xml
+++ b/db/monitor/SPT08C4.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/415 -->
+<!--
+	Conservative profile for Sceptre PNP ID SPT08C4. Its capability string
+	reports the internal model name HKC_MB24S1. Only explicitly named,
+	non-destructive controls from the issue scan are exposed.
+-->
+<monitor name="Sceptre SPT08C4" init="standard">
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 6C 6E 70 AA B0 D6 E1))"/>
+	<controls>
+		<control id="brightness" address="0x10"/>
+		<control id="contrast" address="0x12"/>
+		<control id="red" address="0x16"/>
+		<control id="green" address="0x18"/>
+		<control id="blue" address="0x1A"/>
+		<control id="audiospeakervolume" address="0x62"/>
+
+		<!-- Named controls kept disabled pending hardware verification: -->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0xd6: -/0/65535 C [DPMS Control] -->
+
+		<!-- Destructive controls intentionally kept disabled: -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+
+		<!-- Control 0x60: +/768/4 C [Input Source Select (Main)] -->
+		<!--
+			Unverified candidate mappings based on the advertised capability values
+			and the MCCS standard; keep disabled until tested on this monitor:
+			0x0f = DisplayPort 1, 0x11 = HDMI 1.
+		-->
+
+		<!-- Unknown capability-advertised controls, preserved for investigation: -->
+		<!-- Control 0x0b: -/0/65535 C [???] -->
+		<!-- Control 0x0c: -/0/65535 C [???] -->
+		<!-- Control 0x14: +/6/13 C [???] -->
+		<!-- Control 0x8d: -/0/65535 C [???] -->
+		<!-- Control 0xa8: -/0/65535 C [???] -->
+		<!-- Control 0xac: +/13330/65535 C [???] -->
+		<!-- Control 0xae: +/11998/65535 C [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc6: -/0/65535 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/0/65535 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+
+		<!-- Other readable unknown controls, preserved for investigation: -->
+		<!-- Control 0x59: +/0/100   [???] -->
+		<!-- Control 0x5a: +/0/100   [???] -->
+		<!-- Control 0x5b: +/0/100   [???] -->
+		<!-- Control 0x5d: +/0/100   [???] -->
+		<!-- Control 0x6c: +/50/100   [???] -->
+		<!-- Control 0x6e: +/50/100   [???] -->
+		<!-- Control 0x70: +/50/100   [???] -->
+		<!-- Control 0x87: +/50/100   [???] -->
+		<!-- Control 0x8a: +/50/100   [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xcc: +/0/255   [???] -->
+		<!-- Control 0xed: +/0/1   [???] -->
+
+		<!--
+			The issue probe returned unsupported -/0/65535 responses marked ???
+			for every other address. They are retained compactly as these ranges:
+			0x00-0x01, 0x03, 0x06-0x07, 0x09-0x0a, 0x0d-0x0f, 0x11,
+			0x13, 0x15, 0x17, 0x19, 0x1b-0x58, 0x5c, 0x5e-0x5f, 0x61,
+			0x63-0x6b, 0x6d, 0x6f, 0x71-0x86, 0x88-0x89, 0x8b-0x8c,
+			0x8e-0xa7, 0xa9-0xab, 0xad, 0xaf-0xb1, 0xb3-0xb5,
+			0xb7-0xc5, 0xc7, 0xca-0xcb, 0xcd-0xd5, 0xd7-0xde,
+			0xe0-0xec, 0xee-0xff.
+		-->
+	</controls>
+
+	<!-- VESA controls not explicitly confirmed as safe by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a conservative monitor profile for Sceptre PNP ID SPT08C4
- expose only brightness, contrast, RGB levels, and speaker volume
- keep reset controls and unverified input/DPMS mappings disabled
- preserve unknown controls from the issue scan as commented probe notes

The profile is intentionally conservative for safe distribution. Candidate input-source mappings are commented out, and destructive factory-reset controls are not exposed.

Hardware verification from the issue author is requested before enabling input-source mappings, DPMS values, or any additional controls.

## Validation

- `xmllint --noout db/monitor/SPT08C4.xml`
- `ddccontrol -b db -v -v -i SPT08C4`
- `make check`
- `git diff --check`

Fixes #415