### PR TITLE
feat: add Acer MGB270U P2BIIPX support

### DIFF
--- a/db/monitor/ACR124E.xml
+++ b/db/monitor/ACR124E.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/418 -->
+<monitor name="Acer MGB270U P2BIIPX" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 16 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/0/100 C [Brightness] -->
+		<!-- Control 0x12: +/50/100 C [Contrast] -->
+		<!-- Control 0x16: +/50/100 C [Red maximum level] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset and input controls.
+		-->
+		<!-- Control 0x02: +/1/2 C [New Control Value - No changes] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/18/4 C [Input Source Select (Main)] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x14: +/4/13 C [???] -->
+		<!-- Control 0xac: +/21430/65535   [???] -->
+		<!-- Control 0xae: +/14431/65535   [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/8 C [???] -->
+		<!-- Control 0xc8: +/5/65302 C [???] -->
+		<!-- Control 0xc9: +/0/65535   [???] -->
+		<!-- Control 0xcc: +/2/17 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+		<!-- Control 0xe0: +/1/255 C [???] -->
+		<!-- Control 0xe1: +/1/255   [???] -->
+		<!-- Control 0xe2: +/0/27   [???] -->
+		<!-- Control 0xe3: +/452/27   [???] -->
+		<!-- Control 0xe4: +/258/27   [???] -->
+		<!-- Control 0xe5: +/5/10   [???] -->
+		<!-- Control 0xe6: +/0/1   [???] -->
+		<!-- Control 0xe8: +/0/255   [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
## Summary

- add a profile for the Acer MGB270U P2BIIPX (`ACR124E`)
- expose only explicitly named, non-destructive controls through the VESA profile
- keep reset controls, the unverified input-source candidate, and all unknown controls commented out

The profile is intentionally conservative. No monitor-specific enum mappings are inferred from the scan, and candidate mappings remain disabled.

## Verification

- `xmllint --noout db/monitor/ACR124E.xml`
- `ddccontrol -b db -v -v -i ACR124E`
- `make check`

Hardware verification is requested from the issue author before enabling the input-source control or any additional controls.

Fixes #418