### PR TITLE
feat: add Samsung Odyssey G3 (SAM76E1) support

### DIFF
--- a/db/monitor/SAM76E1.xml
+++ b/db/monitor/SAM76E1.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!-- https://github.com/ddccontrol/ddccontrol-db/issues/414 -->
+<monitor name="Samsung Odyssey G3 LS24DG30X" init="standard">
+	<!--
+		Conservative profile based on issue-provided scan output.
+		Only explicitly named, non-destructive controls are exposed.
+	-->
+	<caps add="(type(lcd)vcp(10 12 18 1A 62 6C 6E 70))" remove="(vcp(00 02 04 05 06 08 0E 16 1C 1E 20 22 24 26 28 30 32 38 3A 3C 3E 40 42 44 46 48 4A 4C 54 56 58 60 AA B0 CC D6 E1))"/>
+	<controls>
+		<!-- Known controls enabled through the VESA include: -->
+		<!-- Control 0x10: +/80/100 C [Brightness] -->
+		<!-- Control 0x12: +/100/100 C [Contrast] -->
+		<!-- Control 0x18: +/50/100 C [Green maximum level] -->
+		<!-- Control 0x1a: +/50/100 C [Blue maximum level] -->
+		<!-- Control 0x62: +/50/100 C [Audio Speaker Volume Adjust] -->
+		<!-- Control 0x6c: +/50/100 C [Red minimum level] -->
+		<!-- Control 0x6e: +/50/100 C [Green minimum level] -->
+		<!-- Control 0x70: +/50/100 C [Blue minimum level] -->
+
+		<!--
+			Named controls kept disabled until their write behavior and values
+			are verified on hardware; this includes reset, input, OSD, language,
+			power, and picture-mode controls.
+		-->
+		<!-- Control 0x02: +/255/255 C [New Control Value] -->
+		<!-- Control 0x04: +/0/1 C [Restore Factory Defaults] -->
+		<!-- Control 0x05: +/0/1 C [Restore Brightness and Contrast] -->
+		<!-- Control 0x08: +/0/1 C [Restore Factory Default Color] -->
+		<!-- Control 0x60: +/15/3 C [Input Source Select (Main) - DP-1] -->
+		<!-- Control 0xca: +/2/2 C [On Screen Display - Enable] -->
+		<!-- Control 0xcc: +/5/255 C [Language - Italiano (Italian)] -->
+		<!-- Control 0xd6: +/1/4 C [DPMS Control - On] -->
+		<!-- Control 0xdc: +/2/3 C [Magic Bright Mode - Internet] -->
+
+		<!-- Unknown controls from the issue output (left commented for future investigation): -->
+		<!-- Control 0x0b: +/50/65535 C [???] -->
+		<!-- Control 0x0c: +/126/170 C [???] -->
+		<!-- Control 0x14: +/11/11 C [???] -->
+		<!-- Control 0x20: +/0/100   [???] -->
+		<!-- Control 0x30: +/0/100   [???] -->
+		<!-- Control 0x3e: +/0/100   [???] -->
+		<!-- Control 0x52: +/0/255   [???] -->
+		<!-- Control 0x78: +/0/255   [???] -->
+		<!-- Control 0x8d: +/2/2 C [???] -->
+		<!-- Control 0xac: +/3392/65283 C [???] -->
+		<!-- Control 0xae: +/18030/65535 C [???] -->
+		<!-- Control 0xb2: +/1/8   [???] -->
+		<!-- Control 0xb6: +/3/4 C [???] -->
+		<!-- Control 0xc0: +/2/65535 C [???] -->
+		<!-- Control 0xc6: +/111/65535 C [???] -->
+		<!-- Control 0xc8: +/18/65535 C [???] -->
+		<!-- Control 0xdf: +/513/65535 C [???] -->
+	</controls>
+	<!-- VESA controls not explicitly confirmed by the scan are removed above. -->
+	<include file="VESA"/>
+</monitor>


### PR DESCRIPTION
Adds a monitor profile for the Samsung Odyssey G3 LS24DG30X (PNP ID SAM76E1).

The profile is intentionally conservative: it exposes only explicitly named, non-destructive value controls from the issue scan. Factory resets, input selection, OSD, language, DPMS, and Magic Bright remain disabled. Unknown controls and candidate mappings are preserved as comments instead of being exposed.

Hardware verification is requested from the issue author before enabling additional controls or adding further enum values, especially input-source mappings.

Validation performed:

- xmllint --noout db/monitor/SAM76E1.xml
- make check
- ddccontrol -b db -v -v -i SAM76E1

Fixes #414