### PR TITLE
feat(SAM7476): add Samsung G95NC rear Core Lighting controls (0xF8/0xF9/0xFA)

### DIFF
--- a/db/monitor/SAM7476.xml
+++ b/db/monitor/SAM7476.xml
@@ -39,9 +39,9 @@
 
 		      Measured on one unit: G95NC, firmware 1009.2, Mstar scaler, over
 		      DisplayPort 2.1. -->
-		<control id="samsung_lighting"/>
-		<control id="samsung_lighting_effect"/>
-		<control id="samsung_lighting_color"/>
+		<control id="samsung_lighting"        address="0xf8"/>
+		<control id="samsung_lighting_effect" address="0xf9"/>
+		<control id="samsung_lighting_color"  address="0xfa"/>
 	</controls>
 </monitor>
 <!--

--- a/db/monitor/SAM7476.xml
+++ b/db/monitor/SAM7476.xml
@@ -39,9 +39,21 @@
 
 		      Measured on one unit: G95NC, firmware 1009.2, Mstar scaler, over
 		      DisplayPort 2.1. -->
-		<control id="samsung_lighting"        address="0xf8"/>
-		<control id="samsung_lighting_effect" address="0xf9"/>
-		<control id="samsung_lighting_color"  address="0xfa"/>
+		<control id="samsung_lighting" address="0xf8">
+			<value id="off"    value="0x00"/>
+			<value id="manual" value="0x01"/>
+		</control>
+		<control id="samsung_lighting_effect" address="0xf9">
+			<value id="aurora"         value="0x00"/>
+			<value id="aurorarotation" value="0x01"/>
+			<value id="comet"          value="0x02"/>
+			<value id="static"         value="0x03"/>
+			<value id="rainbow"        value="0x04"/>
+			<value id="breathing"      value="0x05"/>
+		</control>
+		<!--- 0xFA is a plain value control (a 0..51 palette index), so it has no
+		      enumerated list. -->
+		<control id="samsung_lighting_color" address="0xfa"/>
 	</controls>
 </monitor>
 <!--

--- a/db/monitor/SAM7476.xml
+++ b/db/monitor/SAM7476.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- https://github.com/ddccontrol/ddccontrol-db/issues/261 -->
 <monitor name="Samsung Odyssey Neo G9 LS57CG952NNXZA" init="standard">
-	<caps add="(vcp(2F DB(0 1 2 3 4 5 6 7 8 9)))" />
+	<caps add="(vcp(2F DB(0 1 2 3 4 5 6 7 8 9) F8 F9 FA))" />
 	<include file="SAM7119" />
 	<include file="VESA"/>
 	<controls>
@@ -17,6 +17,31 @@
 			<value id="27_wide_16_9" value="8" />
 			<value id="29_wide_21_9" value="9" />
 		</control>
+
+		<!--- Rear Core Lighting. Manufacturer specific and NOT advertised in the
+		      capabilities string, which is why these three are missing from the
+		      probe dump below.
+
+		      0xF8  lighting source  0x00 off, 0x01 manual, 0x03 CoreSync
+		      0xF9  effect mode      0 Aurora, 1 Aurora Rotation, 2 Comet,
+		                             3 Static, 4 Rainbow, 5 Breathing
+		      0xFA  colour           OSD palette is 13 columns by 4 rows,
+		                             value is row*13 + column (0..51)
+
+		      0xF9 and 0xFA read back 0xfd, above their own declared max, as a
+		      "not applicable" sentinel: lights off, an effect with no colour
+		      option, or CoreSync active.
+
+		      CoreSync (0xF8 = 0x03) is only selectable from the OSD, and only
+		      while the effect is Static. It cannot be entered or left over DDC,
+		      and while active all three codes are locked read-only. It is
+		      therefore readable but deliberately not offered as a settable value.
+
+		      Measured on one unit: G95NC, firmware 1009.2, Mstar scaler, over
+		      DisplayPort 2.1. -->
+		<control id="samsung_lighting"/>
+		<control id="samsung_lighting_effect"/>
+		<control id="samsung_lighting_color"/>
 	</controls>
 </monitor>
 <!--

--- a/db/options.xml.in
+++ b/db/options.xml.in
@@ -993,6 +993,32 @@
 				<value id="100"   name="100"   value="20"/>
 			</control>
 		</subgroup>
+		<subgroup name="Lighting">
+			<!--- Samsung Odyssey Neo G9 57" (G95NC, SAM747B) rear Core Lighting.
+			      Manufacturer specific, not advertised in the capabilities string.
+			      0xF8 value 0x03 (CoreSync, screen-content sync) is deliberately not
+			      offered here: the monitor refuses DDC writes to it in both directions,
+			      so listing it would create a control that silently fails. It stays
+			      readable, and while it is active 0xF8/0xF9/0xFA are all locked
+			      read-only until CoreSync is turned off from the OSD. -->
+			<control id="samsung_lighting" type="list" name="Core Lighting (Samsung)" address="0xf8" refresh="all">
+				<value id="off" name="Off" value="0x00"/>
+				<value id="manual" name="Manual" value="0x01"/>
+			</control>
+			<control id="samsung_lighting_effect" type="list" name="Lighting Effect (Samsung)" address="0xf9" refresh="all">
+				<value id="aurora" name="Aurora" value="0x00"/>
+				<value id="aurorarotation" name="Aurora Rotation" value="0x01"/>
+				<value id="comet" name="Comet" value="0x02"/>
+				<value id="static" name="Static" value="0x03"/>
+				<value id="rainbow" name="Rainbow" value="0x04"/>
+				<value id="breathing" name="Breathing" value="0x05"/>
+			</control>
+			<!--- 0xFA is a 52 entry palette index: the OSD grid is 13 columns by
+			      4 rows and the value is row*13 + column. Exposed as a plain value
+			      rather than a 52 item list. Only meaningful for Comet, Static and
+			      Breathing; the other effects read back 0xfd (not applicable). -->
+			<control id="samsung_lighting_color" type="value" name="Lighting Colour (Samsung)" address="0xfa"/>
+		</subgroup>
 	</group>
 
 </options>


### PR DESCRIPTION
Refs #261. That issue asked for the Odyssey Neo G9 57" Core Lighting to be controllable, to use it as a notification indicator, and closed without it. This adds the three codes it needs.

They are missing from the probe dump at the bottom of `SAM7476.xml` because the monitor does **not** advertise them in its capabilities string. You only find them by walking the manufacturer range by hand.

| VCP | Meaning | Range |
|---|---|---|
| `0xF8` | lighting source: `0x00` off, `0x01` manual, `0x03` CoreSync | max 17 |
| `0xF9` | effect mode | max 5 |
| `0xFA` | colour | max 51 |

`0xF9` maps 1:1 onto the OSD list: `0` Aurora, `1` Aurora Rotation, `2` Comet, `3` Static, `4` Rainbow, `5` Breathing.

`0xFA` is a palette index. The OSD grid is 13 columns by 4 rows, and the value is `row*13 + column`, verified against five independently measured cells (corners are 0 / 12 / 39 / 51).

Both `0xF9` and `0xFA` return `0xfd`, above their own declared max, as a not-applicable sentinel: lights off, an effect with no colour option, or CoreSync active.

### Why CoreSync is not offered as a settable value

`0xF8 = 0x03` is CoreSync. It is readable, but the monitor refuses DDC writes to it in **both** directions, and `--noverify` does not change the read-back either. While it is active, all three codes are locked read-only until it is switched off from the OSD. Listing it would produce a control that silently fails, so this PR exposes only `Off` and `Manual`.

Separately, and possibly useful to other owners: CoreSync being greyed out in the OSD is **not** an HDMI/DisplayPort issue, contrary to what is widely repeated. It is only selectable while the effect is Static. This was measured over DisplayPort.

### Placement

Added to `SAM7476` rather than to one variant, since the lighting belongs to the panel and not to the PBP/input variant. All seven EDID variants that include it benefit.

### Testing and limitations

- XML well-formedness checked for both changed files.
- Register semantics, ranges, writability and the palette formula were measured directly with `ddcutil`.
- I did **not** run a full `ddccontrol` load of the modified database (not installed on this host), so a maintainer sanity check on the `options.xml.in` wiring would be welcome.
- **One unit only**: G95NC, PnP `SAM747B`, firmware 1009.2, Mstar scaler, DisplayPort 2.1, Ubuntu 24.04. Other firmware revisions may differ; happy to adjust if someone reports otherwise.

Full method and a reference script: https://gist.github.com/genedeng-ca/5ac2fb01ed7764c4122e1d2eef354414